### PR TITLE
Add `blame_reference` to viewmodel

### DIFF
--- a/lib/active_record_view_model.rb
+++ b/lib/active_record_view_model.rb
@@ -93,7 +93,7 @@ class ActiveRecordViewModel < ViewModel
         if read_only
           define_method "deserialize_#{attr}" do |value, deserialize_context: self.class.new_deserialize_context|
             if value != self.public_send(attr)
-              raise ViewModel::DeserializationError.new("Cannot edit read only attribute: #{attr}", self.to_reference)
+              raise ViewModel::DeserializationError.new("Cannot edit read only attribute: #{attr}", self.blame_reference)
             end
           end
         else
@@ -120,7 +120,7 @@ class ActiveRecordViewModel < ViewModel
             begin
               model.public_send("#{attr}=", value)
             rescue NameError => ex
-              raise ViewModel::DeserializationError.new("Invalid enumeration constant '#{value}'", self.to_reference)
+              raise ViewModel::DeserializationError.new("Invalid enumeration constant '#{value}'", self.blame_reference)
             end
           end
         end

--- a/lib/active_record_view_model/update_operation.rb
+++ b/lib/active_record_view_model/update_operation.rb
@@ -565,7 +565,7 @@ class ActiveRecordViewModel
     end
 
     def raise_deserialization_error(msg, *args, error: ViewModel::DeserializationError)
-      raise error.new(msg, [self.viewmodel.to_reference], *args)
+      raise error.new(msg, self.viewmodel.blame_reference, *args)
     end
 
     def debug(msg)

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -95,7 +95,7 @@ class ViewModel
 
     # Rebuild this viewmodel from a serialized hash. Must be defined in subclasses.
     def deserialize_from_view(hash_data, deserialize_context: new_deserialize_context)
-      raise DeserializationError.new("Deserialization not defined for '#{self.name}'", self.to_reference)
+      raise DeserializationError.new("Deserialization not defined for '#{self.name}'", self.blame_reference)
     end
 
     def serialize_context_class
@@ -161,6 +161,13 @@ class ViewModel
     ViewModel::Reference.new(self.class, self.try(&:id))
   end
 
+  # When deserializing, if an error occurs within this viewmodel, what viewmodel
+  # is reported as to blame. Can be overridden for example when a viewmodel is
+  # merged with its parent.
+  def blame_reference
+    to_reference
+  end
+
   def preload_for_serialization(serialize_context: self.class.new_serialize_context)
     ViewModel.preload_for_serialization([self], serialize_context: serialize_context)
   end
@@ -181,7 +188,7 @@ class ViewModel
 
   def editable!(deserialize_context: self.class.new_deserialize_context)
     unless editable?(deserialize_context: deserialize_context)
-      raise DeserializationError::Permissions.new("Attempt to edit forbidden viewmodel '#{self.class.name}'", self.to_reference)
+      raise DeserializationError::Permissions.new("Attempt to edit forbidden viewmodel '#{self.class.name}'", self.blame_reference)
     end
   end
 


### PR DESCRIPTION
When deserializing, if an error occurs within a viewmodel, what viewmodel
should be reported as to blame. Can be overridden for example when a
viewmodel is merged with its parent.