### PR TITLE
Update pre_parse_x interface (breaking API change)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'activesupport', '~> 5.0'
 gem 'activerecord',  '~> 5.0'
 
 # Fetch private dependencies from git
-gem 'acts_as_manual_list',          git: 'git@github.com:iknow/acts_as_manual_list'
-gem 'iknow_params',                 git: 'git@github.com:iknow/iknow_params'
-gem 'cerego_active_record_patches', git: 'git@github.com:iknow/cerego_active_record_patches'
-gem 'deep_preloader',               git: 'git@github.com:iknow/deep_preloader'
+gem 'acts_as_manual_list',          git: 'git@github.com:iknow/acts_as_manual_list',          branch: 'master'
+gem 'iknow_params',                 git: 'git@github.com:iknow/iknow_params',                 branch: 'master'
+gem 'cerego_active_record_patches', git: 'git@github.com:iknow/cerego_active_record_patches', branch: 'master'
+gem 'deep_preloader',               git: 'git@github.com:iknow/deep_preloader',               branch: 'master'

--- a/lib/active_record_view_model/update_data.rb
+++ b/lib/active_record_view_model/update_data.rb
@@ -401,13 +401,17 @@ class ActiveRecordViewModel
     end
 
     def parse(hash_data, valid_reference_keys)
-      if hash_data.present? && self.viewmodel_class.respond_to?(:pre_parse)
-        hash_data = self.viewmodel_class.pre_parse(hash_data)
+      hash_data = hash_data.dup
+
+      # handle view pre-parsing if defined
+      self.viewmodel_class.pre_parse(hash_data) if self.viewmodel_class.respond_to?(:pre_parse)
+      hash_data.keys.each do |key|
+        if self.viewmodel_class.respond_to?(:"pre_parse_#{key}")
+          self.viewmodel_class.public_send("pre_parse_#{key}", hash_data, hash_data.delete(key))
+        end
       end
 
       hash_data.each do |name, value|
-        value = self.viewmodel_class.public_send("pre_parse_#{name}", value) if self.viewmodel_class.respond_to?(:"pre_parse_#{name}")
-
         case self.viewmodel_class._members[name]
         when :attribute
           attributes[name] = value

--- a/test/unit/active_record_view_model/customization_test.rb
+++ b/test/unit/active_record_view_model/customization_test.rb
@@ -28,9 +28,9 @@ class ActiveRecordViewModel::SpecializeAssociationTest < ActiveSupport::TestCase
         attributes :text
         association :translations
 
-        def self.pre_parse_translations(user_data)
-          raise "type check" unless user_data.is_a?(Hash) && user_data.all? { |k, v| k.is_a?(String) && v.is_a?(String) }
-          user_data.map { |lang, text| { "_type" => "Translation", "language" => lang, "translation" => text } }
+        def self.pre_parse_translations(hash, translations)
+          raise "type check" unless translations.is_a?(Hash) && translations.all? { |k, v| k.is_a?(String) && v.is_a?(String) }
+          hash["translations"] = translations.map { |lang, text| { "_type" => "Translation", "language" => lang, "translation" => text } }
         end
 
         def resolve_translations(update_datas, previous_translation_views)
@@ -188,13 +188,11 @@ class ActiveRecordViewModel::FlattenAssociationTest < ActiveSupport::TestCase
         association :section_data, viewmodels: [VocabSectionView, QuizSectionView]
 
         def self.pre_parse(user_data)
-          section_type = SectionType.with_name(user_data["section_type"])
-          raise "Invalid section type: #{user_data["section_type"].inspect}" unless section_type
+          section_type_name = user_data.delete("section_type")
+          section_type = SectionType.with_name(section_type_name)
+          raise "Invalid section type: #{section_type_name.inspect}" unless section_type
 
-          user_data.delete("section_type")
           user_data["section_data"] = section_type.construct_hash(user_data.slice!(*self._members.keys))
-
-          user_data
         end
 
         def resolve_section_data(update_data, previous_translation_view)


### PR DESCRIPTION
* pre_parse methods now modify hash in place
* pre_parse_x now is passed the hash and the (removed) value
  from at that key, and is responsible for replacing the mutated
  value.