### PR TITLE
Allow attributes to be serialized/deserialized using simple viewmodels.

### DIFF
--- a/lib/active_record_view_model/update_operation.rb
+++ b/lib/active_record_view_model/update_operation.rb
@@ -107,7 +107,7 @@ class ActiveRecordViewModel
 
           association = model.association(reflection.name)
           child_model = if child_operation
-                          child_operation.run!(deserialize_context: deserialize_context).model
+                          child_operation.run!(deserialize_context: deserialize_context.for_child(viewmodel)).model
                         else
                           nil
                         end
@@ -146,9 +146,9 @@ class ActiveRecordViewModel
             when nil
               nil
             when ActiveRecordViewModel::UpdateOperation
-              child_operation.run!(deserialize_context: deserialize_context).model
+              child_operation.run!(deserialize_context: deserialize_context.for_child(viewmodel)).model
             when Array
-              viewmodels = child_operation.map { |op| op.run!(deserialize_context: deserialize_context) }
+              viewmodels = child_operation.map { |op| op.run!(deserialize_context: deserialize_context.for_child(viewmodel)) }
               viewmodels.map(&:model)
             end
 

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -192,4 +192,15 @@ class ViewModel
     end
   end
 
+  def ==(other_view)
+    other_view.class == self.class && self.class._attributes.all? do |attr|
+      other_view.send(attr) == self.send(attr)
+    end
+  end
+
+  alias :eql? :==
+
+  def hash
+    self.class._attributes.map { |attr| self.send(attr) }.hash
+  end
 end

--- a/lib/view_model/deserialize_context.rb
+++ b/lib/view_model/deserialize_context.rb
@@ -1,8 +1,15 @@
 class ViewModel
   class DeserializeContext
-    attr_accessor :updated_associations
+    attr_accessor :updated_associations, :parent_ref
 
-    def initialize(*)
+    def initialize(parent_ref: nil)
+      self.parent_ref = parent_ref
+    end
+
+    def for_child(parent)
+      self.dup.tap do |copy|
+        copy.parent_ref = parent.to_reference
+      end
     end
   end
 end

--- a/test/unit/active_record_view_model/attribute_view_test.rb
+++ b/test/unit/active_record_view_model/attribute_view_test.rb
@@ -1,0 +1,62 @@
+require_relative "../../helpers/arvm_test_utilities.rb"
+require_relative "../../helpers/arvm_test_models.rb"
+
+require "minitest/autorun"
+
+require "active_record_view_model"
+
+class ActiveRecordViewModel::AttributeViewTest < ActiveSupport::TestCase
+  include ARVMTestUtilities
+
+  class ComplexAttributeView < ViewModel
+    attribute :array
+
+    def serialize_view(json, serialize_context:)
+      json.a array[0]
+      json.b array[1]
+    end
+
+    def self.deserialize_from_view(hash_data, deserialize_context:)
+      array = [hash_data["a"], hash_data["b"]]
+      self.new(array)
+    end
+  end
+
+  def before_all
+    super
+
+    build_viewmodel(:Pair) do
+      define_schema do |t|
+        t.column :pair, "integer[]"
+      end
+
+      define_model do
+      end
+
+      define_viewmodel do
+        attribute :pair, using: ComplexAttributeView
+        include TrivialAccessControl
+      end
+    end
+  end
+
+  def setup
+    super
+    @pair = Pair.create!(pair: [1,2])
+  end
+
+  def test_serialize_view
+    view, _refs = serialize_with_references(PairView.new(@pair))
+
+    assert_equal({ "_type" => "Pair",
+                   "id"    => @pair.id,
+                   "pair"  => { "a" => 1, "b" => 2 }},
+                 view)
+  end
+
+  def test_create
+    view = { "_type" => "Pair", "pair" => { "a" => 3, "b" => 4 } }
+    pv = PairView.deserialize_from_view(view)
+    assert_equal([3,4], pv.model.pair)
+  end
+end


### PR DESCRIPTION
Also, pass a ViewModelRef for the parent viewmodel down through the deserialize_context, to allow non-ARVM (or flattened) children to blame their parents.