### PR TITLE
Fix edit checks for has many through

### DIFF
--- a/test/helpers/arvm_test_models.rb
+++ b/test/helpers/arvm_test_models.rb
@@ -99,6 +99,7 @@ class ARVMBuilder
 
   def initialize(name, &block)
     @name = name.to_s.camelize
+    @no_viewmodel = false
     instance_eval(&block)
     raise "Model not created in ARVMBuilder"     unless model
     raise "Schema not created in ARVMBuilder"    unless model.table_exists?


### PR DESCRIPTION
* Edit check parent if children changed.
* Return updates to be added by caller, for consistency with other builders.
* Construct previous viewmodels in advance.
* Add tests for edit check of parent.