### PR TITLE
Introduce `_version` attribute

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -7,6 +7,7 @@ class ViewModel
   REFERENCE_ATTRIBUTE = "_ref"
   ID_ATTRIBUTE        = "id"
   TYPE_ATTRIBUTE      = "_type"
+  VERSION_ATTRIBUTE   = "_version"
 
   require 'view_model/deserialization_error'
   require 'view_model/serialization_error'
@@ -17,9 +18,11 @@ class ViewModel
 
   class << self
     attr_accessor :_attributes
+    attr_accessor :schema_version
 
     def inherited(subclass)
       subclass._attributes = []
+      subclass.schema_version = 1
     end
 
     def view_name
@@ -114,6 +117,9 @@ class ViewModel
       deserialize_context_class.new(*args)
     end
 
+    def accepts_schema_version?(schema_version)
+      schema_version == self.schema_version
+    end
 
     def preload_for_serialization(viewmodels, serialize_context: new_serialize_context)
       Array.wrap(viewmodels).group_by(&:class).each do |type, views|

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -57,6 +57,8 @@ class ViewModel::ActiveRecord < ViewModel
     end
 
     def inherited(subclass)
+      super
+
       # copy ViewModel setup
       subclass._attributes = self._attributes
 
@@ -387,6 +389,7 @@ class ViewModel::ActiveRecord < ViewModel
   def serialize_view(json, serialize_context: self.class.new_serialize_context)
     json.set!(ViewModel::ID_ATTRIBUTE, model.id)
     json.set!(ViewModel::TYPE_ATTRIBUTE, self.class.view_name)
+    json.set!(ViewModel::VERSION_ATTRIBUTE, self.class.schema_version)
 
     serialize_members(json, serialize_context: serialize_context)
   end

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -31,6 +31,9 @@ class ViewModel
       end
     end
 
+    class SchemaMismatch < DeserializationError
+    end
+
     class NotFound < DeserializationError
       def http_status
         404

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -94,12 +94,14 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
   def test_serialize_view
     view, _refs = serialize_with_references(ParentView.new(@parent1))
 
-    assert_equal({ "_type" => "Parent",
-                   "id" => @parent1.id,
-                   "name" => @parent1.name,
-                   "label" => { "_type" => "Label",
-                                "id" => @parent1.label.id,
-                                "text" => @parent1.label.text },
+    assert_equal({ "_type"    => "Parent",
+                   "_version" => 1,
+                   "id"       => @parent1.id,
+                   "name"     => @parent1.name,
+                   "label"    => { "_type"    => "Label",
+                                   "_version" => 1,
+                                   "id"       => @parent1.label.id,
+                                   "text"     => @parent1.label.text },
                  },
                  view)
   end
@@ -296,9 +298,10 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
 
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
-        assert_equal({ 'id'    => @parent.label.id,
-                       '_type' => 'Label',
-                       'text'  => 'l1'},
+        assert_equal({ 'id'       => @parent.label.id,
+                       '_type'    => 'Label',
+                       '_version' => 1,
+                       'text'     => 'l1' },
                      view['something_else'])
         view['something_else']['text'] = 'new l1 text'
       end

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -325,9 +325,10 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     @parent.reload
 
-    assert_equal({ 'data' => { '_type' => 'Label',
-                               'id'    => @parent.label.id,
-                               'text'  => 'new label' } },
+    assert_equal({ 'data' => { '_type'    => 'Label',
+                               '_version' => 1,
+                               'id'       => @parent.label.id,
+                               'text'     => 'new label' } },
                  labelcontroller.hash_response)
 
     refute_equal(old_label, @parent.label)

--- a/test/unit/view_model/active_record/customization_test.rb
+++ b/test/unit/view_model/active_record/customization_test.rb
@@ -76,9 +76,10 @@ class ViewModel::ActiveRecord::SpecializeAssociationTest < ActiveSupport::TestCa
                                    Translation.new(language: "fr", translation: "chien")])
 
     @text1_view = {
-      "id" => @text1.id,
-      "_type" => "Text",
-      "text"  => "dog",
+      "id"           => @text1.id,
+      "_type"        => "Text",
+      "_version"     => 1,
+      "text"         => "dog",
       "translations" => {
         "ja" => "犬",
         "fr" => "chien"
@@ -225,6 +226,7 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @simplesection_view = {
       "id"           => @simplesection.id,
       "_type"        => "Section",
+      "_version"     => 1,
       "section_type" => "Simple",
       "name"         => "simple1"
     }
@@ -233,6 +235,7 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @quizsection_view = {
       "id"           => @quizsection.id,
       "_type"        => "Section",
+      "_version"     => 1,
       "section_type" => "Quiz",
       "name"         => "quiz1",
       "quiz_name"    => "qq"
@@ -242,6 +245,7 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @vocabsection_view = {
       "id"           => @vocabsection.id,
       "_type"        => "Section",
+      "_version"     => 1,
       "section_type" => "Vocab",
       "name"         => "vocab1",
       "vocab_word"   => "dog"

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -80,12 +80,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     view, _refs = serialize_with_references(ParentView.new(@parent1))
 
 
-    assert_equal({ "_type" => "Parent",
-                   "id" => @parent1.id,
-                   "name" => @parent1.name,
-                   "children" => @parent1.children.map { |child| { "_type" => "Child",
-                                                                   "id" => child.id,
-                                                                   "name" => child.name } } },
+    assert_equal({ "_type"    => "Parent",
+                   "_version" => 1,
+                   "id"       => @parent1.id,
+                   "name"     => @parent1.name,
+                   "children" => @parent1.children.map { |child| { "_type"    => "Child",
+                                                                   "_version" => 1,
+                                                                   "id"       => child.id,
+                                                                   "name"     => child.name } } },
                  view)
   end
 
@@ -770,9 +772,10 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
-        assert_equal([{'id'   => @parent.children.first.id,
-                      '_type' => 'Child',
-                      'name'  => 'c1'}],
+        assert_equal([{ 'id'       => @parent.children.first.id,
+                        '_type'    => 'Child',
+                        '_version' => 1,
+                        'name'     => 'c1' }],
                      view['something_else'])
         view['something_else'][0]['name'] = 'new c1 name'
       end

--- a/test/unit/view_model/active_record/has_many_through_poly_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_poly_test.rb
@@ -172,10 +172,10 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
                                            serialize_context: context_with(:tags))
 
     tag_data = view['tags'].map { |hash| refs[hash['_ref']] }
-    assert_equal([{ 'id' => @tag_a1.id, '_type' => 'TagA', 'name' => 'tag A1' },
-                  { 'id' => @tag_a2.id, '_type' => 'TagA', 'name' => 'tag A2' },
-                  { 'id' => @tag_b1.id, '_type' => 'TagB', 'name' => 'tag B1' },
-                  { 'id' => @tag_b2.id, '_type' => 'TagB', 'name' => 'tag B2' }],
+    assert_equal([{ 'id' => @tag_a1.id, '_type' => 'TagA', '_version' => 1, 'name' => 'tag A1' },
+                  { 'id' => @tag_a2.id, '_type' => 'TagA', '_version' => 1, 'name' => 'tag A2' },
+                  { 'id' => @tag_b1.id, '_type' => 'TagB', '_version' => 1, 'name' => 'tag B1' },
+                  { 'id' => @tag_b2.id, '_type' => 'TagB', '_version' => 1, 'name' => 'tag B2' }],
                  tag_data)
   end
 
@@ -261,9 +261,10 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     def test_renamed_roundtrip
       context = ParentView.new_serialize_context(include: :something_else)
       alter_by_view!(ParentView, @parent, serialize_context: context) do |view, refs|
-        assert_equal({refs.keys.first => {'id' => @parent.parents_tags.first.tag.id,
-                                          '_type' => 'TagA',
-                                          'name' => 'tag A name'}}, refs)
+        assert_equal({refs.keys.first => { 'id'       => @parent.parents_tags.first.tag.id,
+                                           '_type'    => 'TagA',
+                                           '_version' => 1,
+                                           'name'     => 'tag A name' }}, refs)
         assert_equal([{ '_ref' => refs.keys.first }],
                      view['something_else'])
 

--- a/test/unit/view_model/active_record/has_many_through_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_test.rb
@@ -176,8 +176,8 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                                            serialize_context: context_with(:tags))
 
     tag_data = view['tags'].map { |hash| refs[hash['_ref']] }
-    assert_equal([{ 'id' => @tag1.id, '_type' => 'Tag', 'name' => 'tag1' },
-                  { 'id' => @tag2.id, '_type' => 'Tag', 'name' => 'tag2' }],
+    assert_equal([{ 'id' => @tag1.id, '_type' => 'Tag', '_version' => 1, 'name' => 'tag1' },
+                  { 'id' => @tag2.id, '_type' => 'Tag', '_version' => 1, 'name' => 'tag2' }],
                  tag_data)
   end
 
@@ -268,9 +268,10 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     def test_renamed_roundtrip
       context = ParentView.new_serialize_context(include: :something_else)
       alter_by_view!(ParentView, @parent, serialize_context: context) do |view, refs|
-        assert_equal({refs.keys.first => {'id'    => @parent.parents_tags.first.tag.id,
-                                          '_type' => 'Tag',
-                                          'name'  => 'tag name'}}, refs)
+        assert_equal({refs.keys.first => { 'id'       => @parent.parents_tags.first.tag.id,
+                                           '_type'    => 'Tag',
+                                           '_version' => 1,
+                                           'name'     => 'tag name' }}, refs)
         assert_equal([{ '_ref' => refs.keys.first }],
                      view['something_else'])
 

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -96,13 +96,15 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
   def test_serialize_view
     view, _refs = serialize_with_references(ParentView.new(@parent1))
-    assert_equal({ "_type" => "Parent",
-                   "id" => @parent1.id,
-                   "name" => @parent1.name,
-                   "target" => { "_type" => "Target",
-                                 "id" => @parent1.target.id,
-                                 "text" => @parent1.target.text }},
-                view)
+    assert_equal({ "_type"    => "Parent",
+                   "_version" => 1,
+                   "id"       => @parent1.id,
+                   "name"     => @parent1.name,
+                   "target"   => { "_type"    => "Target",
+                                   "_version" => 1,
+                                   "id"       => @parent1.target.id,
+                                   "text"     => @parent1.target.text } },
+                 view)
   end
 
   def test_swap_has_one
@@ -288,9 +290,10 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
-        assert_equal({'id' => @parent.target.id,
-                     '_type' => 'Target',
-                     'text' => 'target text'},
+        assert_equal({ 'id'       => @parent.target.id,
+                       '_type'    => 'Target',
+                       '_version' => 1,
+                       'text'     => 'target text' },
                      view['something_else'])
         view['something_else']['text'] = 'target new text'
       end

--- a/test/unit/view_model/active_record/optional_attribute_view_test.rb
+++ b/test/unit/view_model/active_record/optional_attribute_view_test.rb
@@ -31,8 +31,9 @@ class ViewModel::ActiveRecord::AttributeViewTest < ActiveSupport::TestCase
     super
     @thing = Thing.create!(a: 1, b: 2)
 
-    @skel = { "_type" => "Thing",
-              "id"    => @thing.id }
+    @skel = { "_type"    => "Thing",
+              "_version" => 1,
+              "id"       => @thing.id }
   end
 
   def test_optional_not_serialized

--- a/test/unit/view_model/active_record/shared_test.rb
+++ b/test/unit/view_model/active_record/shared_test.rb
@@ -107,15 +107,17 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
     view, refs = serialize_with_references(ParentView.new(@parent1), serialize_context: serialize_context)
     cat1_ref = refs.detect { |_, v| v['_type'] == 'Category' }.first
 
-    assert_equal({cat1_ref => { '_type' => "Category",
-                                'id'    => @parent1.category.id,
-                                'name'  => @parent1.category.name }},
+    assert_equal({cat1_ref => { '_type'    => "Category",
+                                "_version" => 1,
+                                'id'       => @parent1.category.id,
+                                'name'     => @parent1.category.name }},
                  refs)
 
-    assert_equal({ "_type" => "Parent",
-                   "id" => @parent1.id,
-                   "name" => @parent1.name,
-                   "category" => {"_ref" => cat1_ref}},
+    assert_equal({ "_type"    => "Parent",
+                   "_version" => 1,
+                   "id"       => @parent1.id,
+                   "name"     => @parent1.name,
+                   "category" => { "_ref" => cat1_ref } },
                  view)
   end
 

--- a/test/unit/view_model/active_record/version_test.rb
+++ b/test/unit/view_model/active_record/version_test.rb
@@ -1,0 +1,121 @@
+require_relative "../../../helpers/arvm_test_utilities.rb"
+require_relative "../../../helpers/arvm_test_models.rb"
+
+require "minitest/autorun"
+
+require "view_model/active_record"
+
+class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
+  include ARVMTestUtilities
+
+  def before_all
+    super
+
+    build_viewmodel(:ChildA) do
+      define_schema {}
+      define_model do
+        has_one :parent, inverse_of: :child
+      end
+      define_viewmodel do
+        self.schema_version = 10
+      end
+    end
+
+
+    build_viewmodel(:Target) do
+      define_schema {}
+      define_model do
+        has_one :parent, inverse_of: :target
+      end
+      define_viewmodel do
+        self.schema_version = 20
+      end
+    end
+
+    build_viewmodel(:Parent) do
+      define_schema do |t|
+        t.string :child_type
+        t.integer :child_id
+        t.integer :target_id
+      end
+      define_model do
+        belongs_to :child, polymorphic: true
+        belongs_to :target
+      end
+      define_viewmodel do
+        self.schema_version = 5
+        association :child, viewmodels: [:ChildA]
+        association :target, shared: true, optional: false
+      end
+    end
+  end
+
+  def setup
+    super
+    @parent_with_a = Parent.create(child: ChildA.new, target: Target.new)
+  end
+
+  def test_schema_versions_reflected_in_output
+    data, refs = serialize_with_references(ParentView.new(@parent_with_a))
+
+    target_ref = refs.keys.first
+
+    assert_equal({ '_type'    => 'Parent',
+                   'id'       => @parent_with_a.id,
+                   '_version' => 5,
+                   'child'    => {
+                     '_type'    => 'ChildA',
+                     'id'       => @parent_with_a.child.id,
+                     '_version' => 10,
+                   },
+                   'target'   => { '_ref' => target_ref } },
+                 data)
+
+    assert_equal({ target_ref =>
+                     {
+                       '_type'    => 'Target',
+                       'id'       => @parent_with_a.target.id,
+                       '_version' => 20
+                     } },
+                 refs)
+  end
+
+  def test_regular_version_verification
+    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+      ParentView.deserialize_from_view(
+        { '_type'    => 'Parent',
+          '_new'     => true,
+          '_version' => 99 },)
+    end
+    assert_match(/schema version/, ex.message)
+  end
+
+  def test_polymorphic_version_verification
+    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+      ParentView.deserialize_from_view(
+        { '_type' => 'Parent',
+          '_new'  => true,
+          'child' => {
+            '_type'    => 'ChildA',
+            '_version' => 99,
+          } })
+    end
+    assert_match(/schema version/, ex.message)
+  end
+
+  def test_shared_parse_version_verification
+    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+      ParentView.deserialize_from_view(
+        { '_type'  => 'Parent',
+          '_new'   => true,
+          'target' => { '_ref' => 't1' },
+        },
+        references: { 't1' => {
+          '_type'    => 'Target',
+          '_new'     => true,
+          '_version' => 99,
+        } })
+    end
+    assert_match(/schema version/, ex.message)
+  end
+end

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -287,9 +287,10 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     def test_serialize_view
       view, _refs = serialize_with_references(PairView.new(@pair))
 
-      assert_equal({ "_type" => "Pair",
-                     "id"    => @pair.id,
-                     "pair"  => { "a" => 1, "b" => 2 }},
+      assert_equal({ "_type"    => "Pair",
+                     "_version" => 1,
+                     "id"       => @pair.id,
+                     "pair"     => { "a" => 1, "b" => 2 } },
                    view)
     end
 


### PR DESCRIPTION
These allow the views to declare a version. For VM::AR views, this
version is included by default on serialization and will be checked
deserialization if provided.

For non AR views, this attribute is entirely opt-in, and not serialized
or checked by default.