### PR TITLE
Improve ViewModel access checks

### DIFF
--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -177,7 +177,7 @@ class ViewModel::ActiveRecord < ViewModel
         through_to             = nil
       end
 
-      vm_association_name    = as || association_name
+      vm_association_name    = (as || association_name).to_s
 
       reflection = model_class.reflect_on_association(model_association_name)
 
@@ -187,9 +187,9 @@ class ViewModel::ActiveRecord < ViewModel
 
       viewmodel_spec = viewmodel || viewmodels
 
-      association_data = AssociationData.new(reflection, viewmodel_spec, shared, optional, through_to, through_order_attr)
+      association_data = AssociationData.new(vm_association_name, reflection, viewmodel_spec, shared, optional, through_to, through_order_attr)
 
-      _members[vm_association_name.to_s]      = association_data
+      _members[vm_association_name] = association_data
 
       @generated_accessor_module.module_eval do
         define_method vm_association_name do

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -409,7 +409,7 @@ class ViewModel::ActiveRecord < ViewModel
 
   def destroy!(deserialize_context: self.class.new_deserialize_context)
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context)
+      editable!(deserialize_context: deserialize_context, deleted: true)
       model.destroy!
     end
   end
@@ -432,7 +432,7 @@ class ViewModel::ActiveRecord < ViewModel
     subtree_hashes = Array.wrap(subtree_hashes)
 
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context)
+      editable!(deserialize_context: deserialize_context, changed_associations: [association_name])
 
       association_data = self.class._association_data(association_name)
 
@@ -478,7 +478,7 @@ class ViewModel::ActiveRecord < ViewModel
   # or `:delete_all`
   def delete_associated(association_name, associated, deserialize_context: self.class.new_deserialize_context)
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context)
+      editable!(deserialize_context: deserialize_context, changed_associations: [association_name])
 
       association_data = self.class._association_data(association_name)
 

--- a/lib/view_model/active_record/association_data.rb
+++ b/lib/view_model/active_record/association_data.rb
@@ -1,8 +1,9 @@
 # TODO consider rephrase scope for consistency
 class ViewModel::ActiveRecord::AssociationData
-  attr_reader :direct_reflection
+  attr_reader :direct_reflection, :association_name
 
-  def initialize(direct_reflection, viewmodel_classes, shared, optional, through_to, through_order_attr)
+  def initialize(association_name, direct_reflection, viewmodel_classes, shared, optional, through_to, through_order_attr)
+    @association_name   = association_name
     @direct_reflection  = direct_reflection
     @shared             = shared
     @optional           = optional

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -8,10 +8,10 @@ class ViewModel::ActiveRecord
         model = viewmodel.model
         case association_data.direct_reflection.options[:dependent]
         when :delete
-          viewmodel.editable!(deserialize_context: deserialize_context)
+          viewmodel.editable!(deserialize_context: deserialize_context, deleted: true)
           model.delete
         when :destroy
-          viewmodel.editable!(deserialize_context: deserialize_context)
+          viewmodel.editable!(deserialize_context: deserialize_context, deleted: true)
           model.destroy
         end
       end
@@ -268,7 +268,7 @@ class ViewModel::ActiveRecord
                           update_type: :implicit)
 
       update.build!(self)
-      update.association_changed!
+      update.association_changed!(parent_association_name)
       @root_update_operations << update
       update
     end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -28,7 +28,7 @@ class ViewModel::ActiveRecord
       self.reposition_to = reposition_to
 
       @run_state = RunState::Pending
-      @association_changed = false
+      @changed_associations = []
       @built = false
     end
 
@@ -46,12 +46,12 @@ class ViewModel::ActiveRecord
       @built
     end
 
-    def association_changed!
-      @association_changed = true
+    def association_changed!(association_name)
+      @changed_associations << association_name
     end
 
-    def association_changed?
-      @association_changed
+    def associations_changed?
+      @changed_associations.present?
     end
 
     # Evaluate a built update tree, applying and saving changes to the models.
@@ -119,8 +119,8 @@ class ViewModel::ActiveRecord
         # current state of the model before it is saved. For example, but
         # comparing #foo, #foo_was, #new_record?. Note that edit checks for
         # deletes are handled elsewhere.
-        if model.changed? || association_changed?
-          viewmodel.editable!(deserialize_context: deserialize_context)
+        if model.changed? || associations_changed?
+          viewmodel.editable!(deserialize_context: deserialize_context, changed_associations: @changed_associations)
         end
 
         debug "-> #{debug_name}: Saving"
@@ -175,9 +175,9 @@ class ViewModel::ActiveRecord
         association_data = self.viewmodel.class._association_data(association_name)
         update =
           if association_data.collection?
-            build_updates_for_collection_association(association_data, association_update_data, update_context)
+            build_updates_for_collection_association(association_name, association_data, association_update_data, update_context)
           else
-            build_update_for_single_association(association_data, association_update_data, update_context)
+            build_update_for_single_association(association_name, association_data, association_update_data, update_context)
           end
 
         add_update(association_data, update)
@@ -188,9 +188,9 @@ class ViewModel::ActiveRecord
 
         update =
           if association_data.through?
-            build_updates_for_has_many_through(association_data, reference_string, update_context)
+            build_updates_for_has_many_through(association_name, association_data, reference_string, update_context)
           else
-            build_update_for_single_referenced_association(association_data, reference_string, update_context)
+            build_update_for_single_referenced_association(association_name, association_data, reference_string, update_context)
           end
 
         add_update(association_data, update)
@@ -212,7 +212,7 @@ class ViewModel::ActiveRecord
 
     private
 
-    def build_update_for_single_referenced_association(association_data, reference_string, update_context)
+    def build_update_for_single_referenced_association(association_name, association_data, reference_string, update_context)
       # TODO intern loads for shared items so we only load them once
       model = self.viewmodel.model
       previous_child_viewmodel = model.public_send(association_data.direct_reflection.name).try do |previous_child_model|
@@ -236,7 +236,7 @@ class ViewModel::ActiveRecord
       end
 
       if previous_child_viewmodel != referred_viewmodel
-        self.association_changed!
+        self.association_changed!(association_name)
       end
 
       referred_update
@@ -282,7 +282,7 @@ class ViewModel::ActiveRecord
       was_singular ? resolved_viewmodels.first : resolved_viewmodels
     end
 
-    def build_update_for_single_association(association_data, association_update_data, update_context)
+    def build_update_for_single_association(association_name, association_data, association_update_data, update_context)
       model = self.viewmodel.model
 
       previous_child_viewmodel = model.public_send(association_data.direct_reflection.name).try do |previous_child_model|
@@ -306,7 +306,7 @@ class ViewModel::ActiveRecord
         end
 
       if previous_child_viewmodel != child_viewmodel
-        self.association_changed!
+        self.association_changed!(association_name)
         # free previous child if present
         if previous_child_viewmodel.present?
           if association_data.pointer_location == :local
@@ -356,7 +356,7 @@ class ViewModel::ActiveRecord
       end
     end
 
-    def build_updates_for_collection_association(association_data, association_update, update_context)
+    def build_updates_for_collection_association(association_name, association_data, association_update, update_context)
       model = self.viewmodel.model
 
       # reference back to this model, so we can set the link while updating the children
@@ -458,7 +458,7 @@ class ViewModel::ActiveRecord
       # if the new children differ, mark that one of our associations has
       # changed and release any no-longer-attached children
       if child_viewmodels != previous_child_viewmodels
-        self.association_changed!
+        self.association_changed!(association_name)
         released_child_viewmodels = previous_child_viewmodels - child_viewmodels
         released_child_viewmodels.each do |vm|
           update_context.release_viewmodel(vm, association_data)
@@ -496,7 +496,7 @@ class ViewModel::ActiveRecord
     end
 
     # TODO name isn't generic like all others; why not _collection_referenced_?
-    def build_updates_for_has_many_through(association_data, reference_strings, update_context)
+    def build_updates_for_has_many_through(association_name, association_data, reference_strings, update_context)
       model = self.viewmodel.model
 
       direct_reflection         = association_data.direct_reflection
@@ -538,7 +538,7 @@ class ViewModel::ActiveRecord
       orphaned_through_viewmodels = previous_through_viewmodels_by_indirect_ref.flat_map { |_, vms| vms }
 
       if new_through_viewmodels != previous_through_viewmodels
-        self.association_changed!
+        self.association_changed!(association_name)
       end
 
       positions = Array.new(new_through_viewmodels.length)

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -175,9 +175,9 @@ class ViewModel::ActiveRecord
         association_data = self.viewmodel.class._association_data(association_name)
         update =
           if association_data.collection?
-            build_updates_for_collection_association(association_name, association_data, association_update_data, update_context)
+            build_updates_for_collection_association(association_data, association_update_data, update_context)
           else
-            build_update_for_single_association(association_name, association_data, association_update_data, update_context)
+            build_update_for_single_association(association_data, association_update_data, update_context)
           end
 
         add_update(association_data, update)
@@ -188,9 +188,9 @@ class ViewModel::ActiveRecord
 
         update =
           if association_data.through?
-            build_updates_for_has_many_through(association_name, association_data, reference_string, update_context)
+            build_updates_for_has_many_through(association_data, reference_string, update_context)
           else
-            build_update_for_single_referenced_association(association_name, association_data, reference_string, update_context)
+            build_update_for_single_referenced_association(association_data, reference_string, update_context)
           end
 
         add_update(association_data, update)
@@ -212,7 +212,7 @@ class ViewModel::ActiveRecord
 
     private
 
-    def build_update_for_single_referenced_association(association_name, association_data, reference_string, update_context)
+    def build_update_for_single_referenced_association(association_data, reference_string, update_context)
       # TODO intern loads for shared items so we only load them once
       model = self.viewmodel.model
       previous_child_viewmodel = model.public_send(association_data.direct_reflection.name).try do |previous_child_model|
@@ -236,7 +236,7 @@ class ViewModel::ActiveRecord
       end
 
       if previous_child_viewmodel != referred_viewmodel
-        self.association_changed!(association_name)
+        self.association_changed!(association_data.association_name)
       end
 
       referred_update
@@ -282,7 +282,7 @@ class ViewModel::ActiveRecord
       was_singular ? resolved_viewmodels.first : resolved_viewmodels
     end
 
-    def build_update_for_single_association(association_name, association_data, association_update_data, update_context)
+    def build_update_for_single_association(association_data, association_update_data, update_context)
       model = self.viewmodel.model
 
       previous_child_viewmodel = model.public_send(association_data.direct_reflection.name).try do |previous_child_model|
@@ -306,7 +306,7 @@ class ViewModel::ActiveRecord
         end
 
       if previous_child_viewmodel != child_viewmodel
-        self.association_changed!(association_name)
+        self.association_changed!(association_data.association_name)
         # free previous child if present
         if previous_child_viewmodel.present?
           if association_data.pointer_location == :local
@@ -356,7 +356,7 @@ class ViewModel::ActiveRecord
       end
     end
 
-    def build_updates_for_collection_association(association_name, association_data, association_update, update_context)
+    def build_updates_for_collection_association(association_data, association_update, update_context)
       model = self.viewmodel.model
 
       # reference back to this model, so we can set the link while updating the children
@@ -458,7 +458,7 @@ class ViewModel::ActiveRecord
       # if the new children differ, mark that one of our associations has
       # changed and release any no-longer-attached children
       if child_viewmodels != previous_child_viewmodels
-        self.association_changed!(association_name)
+        self.association_changed!(association_data.association_name)
         released_child_viewmodels = previous_child_viewmodels - child_viewmodels
         released_child_viewmodels.each do |vm|
           update_context.release_viewmodel(vm, association_data)
@@ -496,7 +496,7 @@ class ViewModel::ActiveRecord
     end
 
     # TODO name isn't generic like all others; why not _collection_referenced_?
-    def build_updates_for_has_many_through(association_name, association_data, reference_strings, update_context)
+    def build_updates_for_has_many_through(association_data, reference_strings, update_context)
       model = self.viewmodel.model
 
       direct_reflection         = association_data.direct_reflection
@@ -538,7 +538,7 @@ class ViewModel::ActiveRecord
       orphaned_through_viewmodels = previous_through_viewmodels_by_indirect_ref.flat_map { |_, vms| vms }
 
       if new_through_viewmodels != previous_through_viewmodels
-        self.association_changed!(association_name)
+        self.association_changed!(association_data.association_name)
       end
 
       positions = Array.new(new_through_viewmodels.length)

--- a/test/helpers/arvm_test_models.rb
+++ b/test/helpers/arvm_test_models.rb
@@ -87,7 +87,7 @@ class ViewModelBase < ViewModel::ActiveRecord
     super && context.can_view
   end
 
-  def editable?(deserialize_context:)
+  def editable?(deserialize_context:, changed_associations:, deleted:)
     deserialize_context.log_edit_check(self)
     super && deserialize_context.can_edit
   end


### PR DESCRIPTION
Provide information on what edits have been attempted: pass in `changed_associations` and `deleted` to `editable?`
Allow setting the error to be thrown without overriding `editable!`/`visible!`