### PR TITLE
ViewModel: expose presence of access_check_error

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -222,6 +222,10 @@ class ViewModel
 
   attr_writer :access_check_error
 
+  def has_access_check_error?
+    @access_check_error.present?
+  end
+
   def visible?(context: self.class.new_serialize_context)
     true
   end


### PR DESCRIPTION
Expose only the presence since we don't want modification or further
introspection.