### PR TITLE
Split editable check into editable/valid_edit.

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -248,7 +248,7 @@ class ViewModel
   # and if found false, an error must be raised if an edit is later attempted.
   # To be overridden by viewmodel implementations.
   def editable?(deserialize_context: self.class.new_deserialize_context)
-    visible?(context: deserialize_context)
+    true
   end
 
   # Check that the attempted changes to this record are permitted in the given

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -232,36 +232,113 @@ class ViewModel
     @access_check_error.present?
   end
 
+  # Check that the user is permitted to view the record in its current state, in
+  # the given context. To be overridden by viewmodel implementation.
   def visible?(context: self.class.new_serialize_context)
     true
   end
 
-  def visible!(context: self.class.new_serialize_context)
-    self.access_check_error = nil
-    unless visible?(context: context)
-      raise case
-            when @access_check_error
-              @access_check_error
-            when context.is_a?(DeserializeContext)
-              DeserializationError::Permissions.new("Attempt to deserialize into forbidden viewmodel '#{self.class.view_name}'",
-                                                    self.blame_reference)
-            else
-              SerializationError::Permissions.new("Attempt to serialize forbidden viewmodel '#{self.class.view_name}'")
-            end
-    end
-  end
+  # Editable checks during deserialization are always a combination of
+  # `editable?` and `valid_edit?`, which express the following separate
+  # properties:
 
-  def editable?(deserialize_context: self.class.new_deserialize_context, changed_attributes:, changed_associations:, deleted:)
+  # Check that the record is eligible to be changed in its current state, in the
+  # given context. During deserialization, this must be called before any edits
+  # have taken place (thus checking against the initial state of the viewmodel),
+  # and if found false, an error must be raised if an edit is later attempted.
+  # To be overridden by viewmodel implementations.
+  def editable?(deserialize_context: self.class.new_deserialize_context)
     visible?(context: deserialize_context)
   end
 
-  def editable!(deserialize_context: self.class.new_deserialize_context, changed_attributes: [], changed_associations: [], deleted: false)
+  # Check that the attempted changes to this record are permitted in the given
+  # context. During deserialization, this must be called once all edits have
+  # been attempted. To be overridden by viewmodel implementations.
+  def valid_edit?(deserialize_context: self.class.new_deserialize_context, changes:)
+    true
+  end
+
+  # During deserialization, returns true if the viewmodel was found `editable?`
+  # before any changes were attempted. Takes a viewmodel on which to optionally
+  # set the access check error, which can be used when delegating to a parent
+  # view's editability.
+  def was_editable?(error_view:)
+    unless instance_variable_defined?(:@initial_editable_state) && @initial_editable_state
+      raise DeserializationError.new("Attempted to call `was_editable?` outside deserialization.",
+                                     self.blame_reference)
+    end
+    editable, err = @initial_editable_state
+    error_view.access_check_error = err if err
+    editable
+  end
+
+  # Implementations of serialization and deserialization should call this
+  # whenever a viewmodel is visited during serialization or deserialization.
+  def visible!(context: self.class.new_serialize_context)
     self.access_check_error = nil
-    unless editable?(deserialize_context: deserialize_context, changed_attributes: changed_attributes, changed_associations: changed_associations, deleted: deleted)
-      err = @access_check_error ||
-            DeserializationError::Permissions.new("Attempt to edit forbidden viewmodel '#{self.class.view_name}'",
-                                                  self.blame_reference)
-      raise err
+    unless visible?(context: context)
+      raise_access_check_error do
+        if context.is_a?(DeserializeContext)
+          DeserializationError::Permissions.new("Attempt to deserialize into forbidden viewmodel '#{self.class.view_name}'",
+                                                self.blame_reference)
+        else
+          SerializationError::Permissions.new("Attempt to serialize forbidden viewmodel '#{self.class.view_name}'")
+        end
+      end
+    end
+  end
+
+  # Implementations of deserialization that may or may not make changes to the
+  # viewmodel should call this on the viewmodel to save the initial `editable?`
+  # value and optional exception before attempting to apply their changes.
+  def save_editable!(deserialize_context: self.class.new_deserialize_context)
+    val = editable?(deserialize_context: deserialize_context)
+    @initial_editable_state = [val, @access_check_error]
+    self.access_check_error = nil
+  end
+
+  # Implementations of deserialization that have called `save_editable!` to
+  # cache their initial editable check should call this after they know that a
+  # change will be made.
+  def was_editable!
+    self.access_check_error = nil
+    unless was_editable?(error_view: self)
+      raise_access_check_error do
+        DeserializationError::Permissions.new(
+          "Attempt to edit forbidden viewmodel '#{self.class.view_name}'",
+          self.blame_reference)
+      end
+    end
+    @initial_editable_state = nil
+  end
+
+  # Implementations of deserialization that know in advance that they will make
+  # changes to the viewmodel may call this immediately rather than
+  # `save_editable!` followed by `was_editable!`.
+  def editable!(deserialize_context: self.class.new_deserialize_context)
+    self.access_check_error = nil
+    if instance_variable_defined?(:@initial_editable_state) && @initial_editable_state
+      raise DeserializationError.new("Attempted to call `editable!` during deserialization: use `was_editable!`.", self.blame_reference)
+    end
+    unless editable?(deserialize_context: deserialize_context)
+      raise_access_check_error do
+        DeserializationError::Permissions.new(
+          "Attempt to edit forbidden viewmodel '#{self.class.view_name}'",
+          self.blame_reference)
+      end
+    end
+  end
+
+  # Implementations of deserialization should call this once they have made all
+  # changes that will be performed to the viewmodel.
+  def valid_edit!(deserialize_context: self.class.new_deserialize_context, changes:)
+    self.access_check_error = nil
+    unless valid_edit?(deserialize_context: deserialize_context, changes: changes)
+      raise_access_check_error do
+        DeserializationError::Permissions.new(
+          "Attempt to make illegal changes to viewmodel '#{self.class.view_name}'",
+          self.blame_reference)
+      end
     end
   end
 
@@ -275,6 +352,14 @@ class ViewModel
 
   def hash
     self.class._attributes.map { |attr| self.send(attr) }.hash
+  end
+
+  private
+
+  def raise_access_check_error
+    err = @access_check_error || yield
+    @access_check_error = nil
+    raise err
   end
 end
 

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -269,6 +269,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
 
   def destroy!(deserialize_context: self.class.new_deserialize_context)
     model_class.transaction do
+      visible!(context: deserialize_context)
       editable!(deserialize_context: deserialize_context)
       valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
       model.destroy!

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -269,7 +269,8 @@ class ViewModel::ActiveRecord < ViewModel::Record
 
   def destroy!(deserialize_context: self.class.new_deserialize_context)
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context, deleted: true)
+      editable!(deserialize_context: deserialize_context)
+      valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
       model.destroy!
     end
   end

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -78,7 +78,8 @@ module AssociationManipulation
     subtree_hashes   = Array.wrap(subtree_hashes)
 
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context, changed_associations: [association_name])
+      editable!(deserialize_context: deserialize_context)
+      valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(changed_associations: [association_name]))
 
       if association_data.through?
         raise ArgumentError.new("Polymorphic through relationships not supported yet") if association_data.polymorphic?
@@ -159,7 +160,8 @@ module AssociationManipulation
     target_ref = ViewModel::Reference.new(type || association_data.viewmodel_class, associated_id)
 
     model_class.transaction do
-      editable!(deserialize_context: deserialize_context, changed_associations: [association_name])
+      editable!(deserialize_context: deserialize_context)
+      valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(changed_associations: [association_name]))
 
       association = self.model.association(direct_reflection.name)
       association_scope = association.association_scope
@@ -196,7 +198,8 @@ module AssociationManipulation
       end
 
       vm = direct_viewmodel.new(models.first)
-      vm.editable!(deserialize_context: deserialize_context, deleted: true)
+      vm.editable!(deserialize_context: deserialize_context)
+      vm.valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
       association.delete(vm.model)
     end
   end

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -78,6 +78,7 @@ module AssociationManipulation
     subtree_hashes   = Array.wrap(subtree_hashes)
 
     model_class.transaction do
+      visible!(context: deserialize_context)
       editable!(deserialize_context: deserialize_context)
       valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(changed_associations: [association_name]))
 
@@ -160,6 +161,7 @@ module AssociationManipulation
     target_ref = ViewModel::Reference.new(type || association_data.viewmodel_class, associated_id)
 
     model_class.transaction do
+      visible!(context: deserialize_context)
       editable!(deserialize_context: deserialize_context)
       valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(changed_associations: [association_name]))
 
@@ -198,6 +200,7 @@ module AssociationManipulation
       end
 
       vm = direct_viewmodel.new(models.first)
+      vm.visible!(context: deserialize_context)
       vm.editable!(deserialize_context: deserialize_context)
       vm.valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
       association.delete(vm.model)

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -119,7 +119,7 @@ class ViewModel::ActiveRecord
           functional_update_type.new(functional_updates)
 
         else
-          raise ViewModel::DeserializationError(
+          raise ViewModel::DeserializationError.new(
                   "Could not parse non-array value for collection association '#{association_data}'",
                   blame_reference)
         end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -174,11 +174,12 @@ class ViewModel::ActiveRecord
         debug "-> #{debug_name}: Checking released children permissions"
         self.released_children.reject(&:claimed?).each do |released_child|
           debug "-> #{debug_name}: Checking #{released_child.viewmodel.to_reference}"
-          vm = released_child.viewmodel
-          vm.visible!(context: deserialize_context)
-          vm.editable!(deserialize_context: deserialize_context)
-          vm.valid_edit!(deserialize_context: deserialize_context,
-                         changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
+          child_context = deserialize_context.for_child(viewmodel)
+          child_vm = released_child.viewmodel
+          child_vm.visible!(context: child_context)
+          child_vm.editable!(deserialize_context: child_context)
+          child_vm.valid_edit!(deserialize_context: child_context,
+                               changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
         end
         debug "<- #{debug_name}: Finished checking released children permissions"
       end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -77,6 +77,11 @@ class ViewModel::ActiveRecord
       model.class.transaction do
         viewmodel.visible!(context: deserialize_context)
 
+        # Check that the record is eligible to be edited before any changes are
+        # made. A failure here becomes an error once we've detected a change
+        # being made.
+        viewmodel.save_editable!(deserialize_context: deserialize_context)
+
         # update parent association
         if reparent_to.present?
           debug "-> #{debug_name}: Updating parent pointer to '#{reparent_to.viewmodel.class.view_name}:#{reparent_to.viewmodel.id}'"
@@ -122,7 +127,12 @@ class ViewModel::ActiveRecord
         # comparing #foo, #foo_was, #new_record?. Note that edit checks for
         # deletes are handled elsewhere.
         if model.changed? || associations_changed?
-          viewmodel.editable!(deserialize_context: deserialize_context, changed_attributes: model.changed, changed_associations: @changed_associations)
+          viewmodel.was_editable!
+
+          viewmodel.valid_edit!(deserialize_context: deserialize_context,
+                                changes: ViewModel::DeserializeContext::Changes.new(
+                                  changed_attributes: model.changed,
+                                  changed_associations: @changed_associations))
         end
 
         debug "-> #{debug_name}: Saving"
@@ -164,7 +174,10 @@ class ViewModel::ActiveRecord
         debug "-> #{debug_name}: Checking released children permissions"
         self.released_children.reject(&:claimed?).each do |released_child|
           debug "-> #{debug_name}: Checking #{released_child.viewmodel.to_reference}"
-          released_child.viewmodel.editable!(deserialize_context: deserialize_context, deleted: true)
+          vm = released_child.viewmodel
+          vm.editable!(deserialize_context: deserialize_context)
+          vm.valid_edit!(deserialize_context: deserialize_context,
+                         changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
         end
         debug "<- #{debug_name}: Finished checking released children permissions"
       end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -175,6 +175,7 @@ class ViewModel::ActiveRecord
         self.released_children.reject(&:claimed?).each do |released_child|
           debug "-> #{debug_name}: Checking #{released_child.viewmodel.to_reference}"
           vm = released_child.viewmodel
+          vm.visible!(context: deserialize_context)
           vm.editable!(deserialize_context: deserialize_context)
           vm.valid_edit!(deserialize_context: deserialize_context,
                          changes: ViewModel::DeserializeContext::Changes.new(deleted: true))

--- a/lib/view_model/deserialize_context.rb
+++ b/lib/view_model/deserialize_context.rb
@@ -4,6 +4,26 @@ class ViewModel
     attr_reader :parent_context, :parent_viewmodel
     private :parent_context, :parent_viewmodel
 
+    class Changes
+      attr_reader :changed_attributes, :changed_associations, :deleted
+
+      def initialize(changed_attributes: [], changed_associations: [], deleted: false)
+        @changed_attributes   = changed_attributes
+        @changed_associations = changed_associations
+        @deleted              = deleted
+      end
+
+      def deleted?
+        deleted
+      end
+
+      def contained_to?(associations: [], attributes: [])
+        !deleted? &&
+          changed_associations.all? { |assoc| associations.include?(assoc) } &&
+          changed_attributes.all? { |attr| attributes.include?(attr) }
+      end
+    end
+
     def initialize(*)
     end
 

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -94,13 +94,20 @@ class ViewModel::Record < ViewModel
                                                   viewmodel.blame_reference)
       end
 
+      viewmodel.save_editable!(deserialize_context: deserialize_context)
+
       _members.each do |attr, _|
         if view_hash.has_key?(attr)
           viewmodel.public_send("deserialize_#{attr}", view_hash[attr], deserialize_context: deserialize_context)
         end
       end
 
-      viewmodel.editable!(deserialize_context: deserialize_context, changed_attributes: viewmodel.changed_attributes)
+      if viewmodel.changed_attributes.present?
+        viewmodel.was_editable!
+        viewmodel.valid_edit!(deserialize_context: deserialize_context,
+                              changes: ViewModel::DeserializeContext::Changes.new(changed_attributes: viewmodel.changed_attributes))
+      end
+
       viewmodel.clear_changed_attributes!
     end
 

--- a/test/helpers/arvm_test_utilities.rb
+++ b/test/helpers/arvm_test_utilities.rb
@@ -86,7 +86,7 @@ module ARVMTestUtilities
   end
 
   def enable_logging!
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    ActiveRecord::Base.logger = Logger.new(STDERR)
   end
 
 

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -231,8 +231,8 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     assert_equal(target_label, to_parent.label, 'target label moved')
     assert_equal([ViewModel::Reference.new(ParentView, from_parent.id),
                   ViewModel::Reference.new(ParentView, to_parent.id)],
-                 d_context.edit_checks,
-                 "only parents are edit checked; child was not")
+                 d_context.valid_edit_checks,
+                 "only parents are checked for change; child was not")
   end
 
   def test_implicit_release_invalid_belongs_to

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -156,7 +156,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     assert_equal({ ViewModel::Reference.new(ParentView, nil) => 1,
                    ViewModel::Reference.new(ChildView,  nil) => 2 },
-                 count_all(context.edit_checks))
+                 count_all(context.valid_edit_checks))
 
     assert_equal(%w(c1 c2), pv.model.children.map(&:name))
   end
@@ -212,7 +212,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                            old_children.map { |x| ViewModel::Reference.new(ChildView, x.id) }
 
     assert_equal(Set.new(expected_edit_checks),
-                 context.edit_checks.to_set)
+                 context.valid_edit_checks.to_set)
 
     assert_equal(1, nc.size)
     assert_equal('new_child', nc[0].name)
@@ -232,7 +232,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                            old_children.map { |x| ViewModel::Reference.new(ChildView, x.id) }
 
     assert_equal(Set.new(expected_edit_checks),
-                 context.edit_checks.to_set)
+                 context.valid_edit_checks.to_set)
 
     assert_equal([], @parent1.children, 'no children associated with parent1')
     assert(Child.where(id: old_children.map(&:id)).blank?, 'all children deleted')
@@ -251,7 +251,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                             ViewModel::Reference.new(ChildView,  c1.id)].to_set
 
     assert_equal(expected_edit_checks,
-                 context.edit_checks.to_set)
+                 context.valid_edit_checks.to_set)
 
     @parent1.reload
     assert_equal([c2, c3], @parent1.children.order(:position))
@@ -269,7 +269,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                    ViewModel::Reference.new(ChildView,  c1.id)       => 1, # deleted child
                    ViewModel::Reference.new(ChildView,  nil)         => 1, # created child
                  },
-                 count_all(context.edit_checks))
+                 count_all(context.valid_edit_checks))
 
     assert_equal([c2, c3, Child.find_by_name('new_c')],
                  @parent1.children.order(:position))
@@ -289,7 +289,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                          before: ViewModel::Reference.new(ChildView, c1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
 
     assert_equal([c3, c1, c2],
@@ -301,7 +301,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                          after: ViewModel::Reference.new(ChildView, c1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     assert_equal([c1, c3, c2],
                  @parent1.children.order(:position))
@@ -325,7 +325,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                             ViewModel::Reference.new(ParentView, @parent2.id),
                             ViewModel::Reference.new(ChildView, p2c1.id)].to_set
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     assert_equal([c1, c2, c3, p2c1],
                  @parent1.children.order(:position))
@@ -344,7 +344,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                          before: ViewModel::Reference.new(ChildView, c2.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     n1 = Child.find_by_name("new1")
 
@@ -357,7 +357,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                          after: ViewModel::Reference.new(ChildView, c2.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     n2 = Child.find_by_name("new2")
 
@@ -458,7 +458,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
                    ViewModel::Reference.new(ChildView,  nil)            => 1,
                    ViewModel::Reference.new(ChildView,  moved_child.id) => 1,
                    ViewModel::Reference.new(ParentView, @parent1.id)    => 1 },
-                 count_all(deserialize_context.edit_checks))
+                 count_all(deserialize_context.valid_edit_checks))
 
     # child should be removed from old parent
     @parent1.reload

--- a/test/unit/view_model/active_record/has_many_through_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_test.rb
@@ -211,8 +211,8 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     alter_by_view!(ParentView, @parent1, serialize_context: context_with(:tags), deserialize_context: d_context) do |view, refs|
       refs[view['tags'][0]["_ref"]]["name"] = "changed"
     end
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(TagView, @parent1.parents_tags.order(:position).first.tag_id)))
-    refute(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(TagView, @parent1.parents_tags.order(:position).first.tag_id)))
+    refute(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 
   def test_child_reordering_editchecks_parent
@@ -220,7 +220,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     alter_by_view!(ParentView, @parent1, serialize_context: context_with(:tags), deserialize_context: d_context) do |view, refs|
       view['tags'].reverse!
     end
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 
   def test_child_deletion_editchecks_parent
@@ -229,7 +229,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
       removed = view['tags'].pop['_ref']
       refs.delete(removed)
     end
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 
   def test_child_addition_editchecks_parent
@@ -238,8 +238,8 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
       view['tags'] << { '_ref' => 't_new' }
       refs['t_new'] = { '_type' => 'Tag', 'name' => 'newest tag' }
     end
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(TagView, nil)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(TagView, nil)))
   end
 
   def tags(parent)
@@ -446,8 +446,8 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     ParentView.deserialize_from_view(view, references: refs,
                                      deserialize_context: d_context)
 
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(TagView, nil)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(TagView, nil)))
   end
 
   def test_replace_associated
@@ -463,7 +463,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                             ViewModel::Reference.new(TagView,  nil)]
 
     assert_equal(Set.new(expected_edit_checks),
-                 context.edit_checks.to_set)
+                 context.valid_edit_checks.to_set)
 
     assert_equal(1, nc.size)
     assert(nc[0].is_a?(TagView))
@@ -485,7 +485,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     expected_edit_checks = [ViewModel::Reference.new(ParentView, @parent1.id)].to_set
 
     assert_equal(expected_edit_checks,
-                 context.edit_checks.to_set)
+                 context.valid_edit_checks.to_set)
 
     @parent1.reload
     assert_equal([t2], tags(@parent1))
@@ -502,7 +502,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                          before: ViewModel::Reference.new(TagView, @tag1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
 
     assert_equal([@tag2, @tag1],
@@ -514,7 +514,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                          after: ViewModel::Reference.new(TagView, @tag1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     assert_equal([@tag1, @tag2],
                  tags(@parent1))
@@ -540,7 +540,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                          before: ViewModel::Reference.new(TagView, @tag1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     assert_equal([@tag3, @tag1, @tag2],
                  tags(@parent1))
@@ -553,7 +553,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
                          after: ViewModel::Reference.new(TagView, @tag1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
-    assert_equal(expected_edit_checks, context.edit_checks.to_set)
+    assert_equal(expected_edit_checks, context.valid_edit_checks.to_set)
 
     assert_equal([@tag1, @tag3, @tag2],
                  tags(@parent1))

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -122,7 +122,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
                           ViewModel::Reference.new(ParentView, @parent2.id),
                           ViewModel::Reference.new(TargetView, t1.id),
                           ViewModel::Reference.new(TargetView, t2.id)]),
-                 deserialize_context.edit_checks.to_set)
+                 deserialize_context.valid_edit_checks.to_set)
 
     @parent1.reload
     @parent2.reload

--- a/test/unit/view_model/active_record/shared_test.rb
+++ b/test/unit/view_model/active_record/shared_test.rb
@@ -237,8 +237,8 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
       refs[view['category']["_ref"]]["name"] = "changed"
     end
 
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(CategoryView, @parent1.category.id)))
-    refute(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(CategoryView, @parent1.category.id)))
+    refute(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 
   def test_child_change_editchecks_parent
@@ -251,8 +251,8 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
       refs['new_cat'] = { "_type" => "Category", "name" => "new category"}
     end
 
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(CategoryView, nil)))
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(CategoryView, nil)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 
   def test_child_delete_editchecks_parent
@@ -264,6 +264,6 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
       view['category'] = nil
     end
 
-    assert(d_context.edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
 end

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -126,7 +126,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     context = ViewModelBase.new_deserialize_context
     ParentView.deserialize_from_view({'_type' => 'Parent', 'name' => 'p'},
                                         deserialize_context: context)
-    assert_equal([ViewModel::Reference.new(ParentView, nil)], context.edit_checks)
+    assert_equal([ViewModel::Reference.new(ParentView, nil)], context.valid_edit_checks)
   end
 
   def test_editability_raises
@@ -265,9 +265,9 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
           attribute   :car
           association :cdr
 
-          def editable?(deserialize_context:, changed_attributes:, changed_associations:, deleted:)
+          def valid_edit?(deserialize_context:, changes:)
             EditCheckTests.add_edit_check(self.to_reference,
-                                          [changed_attributes, changed_associations, deleted])
+                                          [changes.changed_attributes, changes.changed_associations, changes.deleted])
             super
           end
         end


### PR DESCRIPTION
This allows us to separate the check that a model (in its current state)
can be edited from the check that the specified changes may be made.
Particularly this allows us to delegate basic editability from a parent
view to children.