### PR TITLE
Minor changes to support caching

### DIFF
--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -127,19 +127,31 @@ class ViewModel::ActiveRecord < ViewModel::Record
       assocs.each { |assoc| association(assoc, **args) }
     end
 
-    ## Load an instance of the viewmodel by id
-    def find(id, scope: nil, eager_include: true, serialize_context: new_serialize_context)
+    ## Load instances of the viewmodel by id(s)
+    def find(ids, scope: nil, eager_include: true, serialize_context: new_serialize_context)
       find_scope = self.model_class.all
       find_scope = find_scope.merge(scope) if scope
 
-      ref = ViewModel::Reference.new(self, id)
-      model = ViewModel::DeserializationError::NotFound.wrap_lookup(ref) do
-        find_scope.find(id)
+      find_all = ids.is_a?(Array)
+      ids = Array.wrap(ids)
+
+      models = find_scope.where(id: ids).to_a
+
+      if models.size < ids.size
+        missing_ids = ids - models.map(&:id)
+        raise ViewModel::DeserializationError::NotFound.new(
+                "Couldn't find #{self.model_class.name}(s) with id(s)=#{missing_ids.inspect}",
+                missing_ids.map { |id| ViewModel::Reference.new(self, id) } )
       end
 
-      vm = self.new(model)
-      ViewModel.preload_for_serialization(vm, serialize_context: serialize_context) if eager_include
-      vm
+      vms = models.map { |m| self.new(m) }
+      ViewModel.preload_for_serialization(vms, serialize_context: serialize_context) if eager_include
+
+      if find_all
+        vms
+      else
+        vms.first
+      end
     end
 
     ## Load instances of the viewmodel by scope

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -139,9 +139,11 @@ class ViewModel::ActiveRecord < ViewModel::Record
 
       if models.size < ids.size
         missing_ids = ids - models.map(&:id)
-        raise ViewModel::DeserializationError::NotFound.new(
-                "Couldn't find #{self.model_class.name}(s) with id(s)=#{missing_ids.inspect}",
-                missing_ids.map { |id| ViewModel::Reference.new(self, id) } )
+        if missing_ids.present?
+          raise ViewModel::DeserializationError::NotFound.new(
+                  "Couldn't find #{self.model_class.name}(s) with id(s)=#{missing_ids.inspect}",
+                  missing_ids.map { |id| ViewModel::Reference.new(self, id) } )
+        end
       end
 
       vms = models.map { |m| self.new(m) }

--- a/lib/view_model/serialize_context.rb
+++ b/lib/view_model/serialize_context.rb
@@ -8,8 +8,8 @@ class ViewModel
     def initialize(include: nil, prune: nil, flatten_references: false)
       @references = References.new
       self.flatten_references = flatten_references
-      self.include = normalize_includes(include)
-      self.prune   = normalize_includes(prune)
+      self.include = self.class.normalize_includes(include)
+      self.prune   = self.class.normalize_includes(prune)
     end
 
     def for_association(association_name)
@@ -35,13 +35,13 @@ class ViewModel
     def add_includes(includes)
       return if includes.blank?
       self.include ||= {}
-      self.include.deep_merge!(normalize_includes(includes))
+      self.include.deep_merge!(self.class.normalize_includes(includes))
     end
 
     def add_prunes(prunes)
       return if prunes.blank?
       self.prune ||= {}
-      self.prune.deep_merge!(normalize_includes(prunes))
+      self.prune.deep_merge!(self.class.normalize_includes(prunes))
     end
 
     # Return viewmodels referenced during serialization and clear @references.
@@ -68,9 +68,7 @@ class ViewModel
       Jbuilder.new { |json| serialize_references(json) }.attributes!
     end
 
-    private
-
-    def normalize_includes(includes)
+    def self.normalize_includes(includes)
       case includes
       when Array
         includes.each_with_object({}) do |v, new_includes|

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -120,7 +120,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     assert_equal(404, parentcontroller.status)
     assert_equal({ 'errors' => [{ 'status' => 404,
-                                  'detail' => "Couldn't find Parent with 'id'=9999",
+                                  'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
                                   'code'   => "Deserialization.NotFound",
                                   'meta' => { 'nodes' => [{ '_type' => "Parent", 'id' => 9999 }]}}]},
                  parentcontroller.hash_response)
@@ -160,7 +160,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     parentcontroller.invoke(:destroy)
 
     assert_equal({ 'errors' => [{ 'status' => 404,
-                                  'detail' => "Couldn't find Parent with 'id'=9999",
+                                  'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
                                   'code'   => "Deserialization.NotFound",
                                   'meta' => { "nodes" => [{"_type" => "Parent", "id" => 9999}]}}] },
                  parentcontroller.hash_response)

--- a/test/unit/view_model/active_record/shared_test.rb
+++ b/test/unit/view_model/active_record/shared_test.rb
@@ -266,4 +266,23 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
 
     assert(d_context.valid_edit_checks.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
   end
+
+  def test_dependent_viewmodels
+    deps = ParentView.dependent_viewmodels
+    assert_equal([ParentView, CategoryView].to_set, deps)
+
+    deps = ParentView.dependent_viewmodels(include_shared: false)
+    assert_equal([ParentView].to_set, deps)
+  end
+
+  def test_deep_schema_version
+    vers = ParentView.deep_schema_version
+    assert_equal({ ParentView.view_name   => ParentView.schema_version,
+                   CategoryView.view_name => CategoryView.schema_version },
+                 vers)
+
+    vers = ParentView.deep_schema_version(include_shared: false)
+    assert_equal({ ParentView.view_name => ParentView.schema_version },
+                 vers)
+  end
 end

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -47,6 +47,19 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal(@parent1, parentview.model)
   end
 
+  def test_find_multiple
+    pv1, pv2 = ParentView.find([@parent1.id, @parent2.id])
+    assert_equal(@parent1, pv1.model)
+    assert_equal(@parent2, pv2.model)
+  end
+
+  def test_find_errors
+    ex = assert_raises(ViewModel::DeserializationError::NotFound) do
+      ParentView.find([@parent1.id, 9999])
+    end
+    assert_equal([ViewModel::Reference.new(ParentView, 9999)], ex.nodes)
+  end
+
   def test_load
     parentviews = ParentView.load
     assert_equal(2, parentviews.size)


### PR DESCRIPTION
* Shared references no longer share `prune`/`include` serialize context from their root.
* `prune`/`include` normalization is now no longer private, so that library users can compare normalized specifications.
* `VM::AR#find` now supports multiple records, like modern AR's find.
* `dependent_viewmodels`/`deep_schema_version` now have the option to exclude shared references.
