### PR TITLE
Render viewmodels after commit

### DIFF
--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -39,7 +39,8 @@ module ViewModel::ActiveRecord::CollectionNestedController
   # Deserialize items of the associated type and append them to the owner's
   # collection.
   def append(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
-    owner_viewmodel.transaction do
+    assoc_view = nil
+    pre_rendered = owner_viewmodel.transaction do
       update_hash, refs = parse_viewmodel_updates
 
       before = parse_relative_position(:before)
@@ -60,9 +61,10 @@ module ViewModel::ActiveRecord::CollectionNestedController
                                                 deserialize_context: deserialize_context)
 
       ViewModel.preload_for_serialization(assoc_view, serialize_context: serialize_context)
-      render_viewmodel(assoc_view, serialize_context: serialize_context)
-      assoc_view
+      prerender_viewmodel(assoc_view, serialize_context: serialize_context)
     end
+    finish_render_viewmodel(pre_rendered)
+    assoc_view
   end
 
   def disassociate(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)

--- a/lib/view_model/active_record/controller_base.rb
+++ b/lib/view_model/active_record/controller_base.rb
@@ -8,8 +8,12 @@ module ControllerBase
 
   protected
 
-  # Override render_viewmodel to use the default serialization context from this controller.
+  # Override (pre)render_viewmodel to use the default serialization context from this controller.
   def render_viewmodel(viewmodel, serialize_context: new_serialize_context, **args)
+    super(viewmodel, serialize_context: serialize_context, **args)
+  end
+
+  def prerender_viewmodel(viewmodel, serialize_context: new_serialize_context, **args)
     super(viewmodel, serialize_context: serialize_context, **args)
   end
 

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -84,12 +84,6 @@ module ViewModel::Controller
   end
 
   def render_json_string(response, status:)
-    ## jbuilder prevents this from working
-    ##  - https://github.com/rails/jbuilder/issues/317
-    ##  - https://github.com/rails/rails/issues/23923
-
-    # render(json: response, status: status)
-
-    render(plain: response, status: status, content_type: 'application/json')
+    render(json: response, status: status)
   end
 end

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -9,8 +9,13 @@ module ViewModel::Controller
     end
   end
 
-  def render_viewmodel(viewmodel, status: nil, serialize_context: viewmodel.class.try(:new_serialize_context))
-    render_jbuilder(status: status) do |json|
+  def render_viewmodel(viewmodel, status: nil, serialize_context: viewmodel.class.try(:new_serialize_context), &block)
+    prerender = prerender_viewmodel(viewmodel, serialize_context: serialize_context, &block)
+    finish_render_viewmodel(prerender, status: status)
+  end
+
+  def prerender_viewmodel(viewmodel, status: nil, serialize_context: viewmodel.class.try(:new_serialize_context))
+    Jbuilder.encode do |json|
       json.data do
         ViewModel.serialize(viewmodel, json, serialize_context: serialize_context)
       end
@@ -23,6 +28,10 @@ module ViewModel::Controller
 
       yield(json) if block_given?
     end
+  end
+
+  def finish_render_viewmodel(pre_rendered, status: nil)
+    render_json_string(pre_rendered, status: status)
   end
 
   def render_errors(error_views, status = 500)
@@ -71,6 +80,10 @@ module ViewModel::Controller
       yield json
     end
 
+    render_json_string(response, status: status)
+  end
+
+  def render_json_string(response, status:)
     ## jbuilder prevents this from working
     ##  - https://github.com/rails/jbuilder/issues/317
     ##  - https://github.com/rails/rails/issues/23923


### PR DESCRIPTION
Prevents DoubleRenderError when the commit fails. Typically applications
will `rescue_from` with some kind of `render` based handler. If we've
rendered inside the transaction then transaction failures will always
double render.