### PR TITLE
viewmodel changes should be recorded as strings

### DIFF
--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -49,7 +49,7 @@ class ViewModel::ActiveRecord
     end
 
     def association_changed!(association_name)
-      @changed_associations << association_name
+      @changed_associations << association_name.to_s
     end
 
     def associations_changed?

--- a/lib/view_model/deserialize_context.rb
+++ b/lib/view_model/deserialize_context.rb
@@ -19,8 +19,8 @@ class ViewModel
 
       def contained_to?(associations: [], attributes: [])
         !deleted? &&
-          changed_associations.all? { |assoc| associations.include?(assoc) } &&
-          changed_attributes.all? { |attr| attributes.include?(attr) }
+          changed_associations.all? { |assoc| associations.include?(assoc.to_s) } &&
+          changed_attributes.all? { |attr| attributes.include?(attr.to_s) }
       end
     end
 


### PR DESCRIPTION
Fix this, and add a test.