### PR TITLE
Clear references before recursing into their deserialization to avoid…

### DIFF
--- a/lib/view_model/references.rb
+++ b/lib/view_model/references.rb
@@ -1,7 +1,7 @@
 class ViewModel
   # A bucket for configuration, used for serializing and deserializing.
   class References
-    delegate :each, :size, to: :@value_by_ref
+    delegate :each, :size, :present?, to: :@value_by_ref
 
     def initialize
       @last_ref = 0

--- a/lib/view_model/serialize_context.rb
+++ b/lib/view_model/serialize_context.rb
@@ -64,8 +64,8 @@ class ViewModel
       reference_context = self.for_references
 
       seen = Set.new
-      while seen.size != @references.size
-        @references.each do |ref, value|
+      while @references.present?
+        extract_referenced_views!.each do |ref, value|
           if seen.add?(ref)
             json.set!(ref) do
               ViewModel.serialize(value, json, serialize_context: reference_context)


### PR DESCRIPTION
… concurrent modification.