### PR TITLE
Independent access control

### DIFF
--- a/lib/view_model/access_control.rb
+++ b/lib/view_model/access_control.rb
@@ -1,0 +1,130 @@
+require 'view_model/access_control_error'
+
+## Defines an access control discipline for a given action against a viewmodel.
+##
+## Access control is based around three edit check hooks: visible, editable and
+## valid_edit. The visible determines whether a view can be seen. The editable
+## check determines whether a view in its current state is eligible to be
+## changed. The valid_edit change determines whether an attempted change is
+## permitted. Each edit check returns a pair of boolean success and optional
+## exception to raise.
+class ViewModel::AccessControl
+  Result = Struct.new(:permit, :error) do
+    def initialize(permit, error: nil)
+      raise ArgumentError.new("Successful AccessControl::Result may not have an error") if permit && error
+      super(permit, error)
+    end
+
+    alias :permit? :permit
+
+    # Merge this result with another access control result. Takes a block
+    # returning a result, and returns a combined result for both tests. Access
+    # is permitted if both results permit. Otherwise, access is denied with the
+    # error value of the first denying Result.
+    def merge(&block)
+      if permit?
+        yield
+      else
+        self
+      end
+    end
+  end
+
+  Result::PERMIT = Result.new(true).freeze
+  Result::DENY   = Result.new(false).freeze
+
+  # Check that the user is permitted to view the record in its current state, in
+  # the given context.
+  def visible_check(view, context:)
+    Result::DENY
+  end
+
+  # Editable checks during deserialization are always a combination of
+  # `editable_check` and `valid_edit_check`, which express the following
+  # separate properties. `editable!` passes if both checks are successful.
+
+  # Check that the record is eligible to be changed in its current state, in the
+  # given context. During deserialization, this must be called before any edits
+  # have taken place (thus checking against the initial state of the viewmodel),
+  # and if edit is denied, an error must be raised if an edit is later
+  # attempted. To be overridden by viewmodel implementations.
+  def editable_check(view, deserialize_context:)
+    Result::DENY
+  end
+
+  # Check that the attempted changes to this record are permitted in the given
+  # context. During deserialization, this must be called once all edits have
+  # been attempted. To be overridden by viewmodel implementations.
+  def valid_edit_check(view, deserialize_context:, changes:)
+    Result::DENY
+  end
+
+  # Implementations of deserialization that will potentially make changes to the
+  # viewmodel or any of its descendents must call this on the unmodified
+  # viewmodel to obtain an initial `editable_check` result before attempting to
+  # apply their changes or recursing to children. This result must then be
+  # passed to `editable!` as `initial_editability` after changes have been
+  # applied.
+  def initial_editability(view, deserialize_context:)
+    return nil if ineligible(view)
+    editable_check(view, deserialize_context: deserialize_context)
+  end
+
+  # Implementations of serialization and deserialization must call this
+  # whenever a viewmodel is visited during serialization or deserialization.
+  def visible!(view, context:)
+    return if ineligible(view)
+
+    result = visible_check(view, context: context)
+
+    raise_if_error!(result) do
+      message =
+        if context.is_a?(ViewModel::DeserializeContext)
+          "Attempt to deserialize into forbidden viewmodel '#{view.class.view_name}'"
+        else
+          "Attempt to serialize forbidden viewmodel '#{view.class.view_name}'"
+        end
+
+      ViewModel::AccessControlError.new(message, view.blame_reference)
+    end
+  end
+
+  # Implementations of deserialization must call this when they know what
+  # changes are to be made to the viewmodel. For viewmodels with transactional
+  # backing models, the changes may be made in advance to give the edit checks
+  # the opportunity to compare values. Must be called with the saved
+  # `initial_editability` value if changes have been made.
+  def editable!(view, initial_editability: nil, deserialize_context:, changes:)
+    return if ineligible(view)
+
+    initial_editability ||= editable_check(view, deserialize_context: deserialize_context)
+
+    result = initial_editability.merge do
+      valid_edit_check(view, deserialize_context: deserialize_context, changes: changes)
+    end
+
+    raise_if_error!(result) do
+      ViewModel::AccessControlError.new(
+        "Illegal edit to viewmodel '#{view.class.view_name}'",
+        view.blame_reference)
+    end
+  end
+
+  private
+
+  def ineligible(view)
+    # ARVM synthetic views are considered part of their association and as such
+    # are not edit checked. Eligibility exclusion is intended to be
+    # library-internal: subclasses should not attempt to extend this.
+    view.is_a?(ViewModel::ActiveRecord) && view.class.synthetic
+  end
+
+  def raise_if_error!(result)
+    raise (result.error || yield) unless result.permit?
+  end
+end
+
+require 'view_model/access_control/open'
+require 'view_model/access_control/read_only'
+require 'view_model/access_control/composed'
+require 'view_model/access_control/tree'

--- a/lib/view_model/access_control/composed.rb
+++ b/lib/view_model/access_control/composed.rb
@@ -1,0 +1,246 @@
+## Provides access control as a combination of `x_if!` and `x_unless!` checks
+## for each access check (visible, editable, edit_valid). An action is permitted
+## if at least one `if` check and no `unless` checks succeed. For example:
+##    edit_valid_if!("logged in as specified user") { ... }
+##    edit_valid_unless!("user is on fire") { ... }
+class ViewModel::AccessControl::Composed < ViewModel::AccessControl
+  ComposedResult = Struct.new(:allow, :veto, :allow_error, :veto_error) do
+    def initialize(allow, veto, allow_error, veto_error)
+      raise ArgumentError.new("Non-vetoing result may not have a veto error") if veto_error  && !veto
+      raise ArgumentError.new("Allowing result may not have a allow error")   if allow_error && allow
+      super
+    end
+
+    def permit?
+      !veto && allow
+    end
+
+    def error
+      case
+      when veto;   veto_error
+      when !allow; allow_error
+      else;        nil
+      end
+    end
+
+    # Merge this composed result with another. `allow`s widen and `veto`es narrow.
+    def merge(&block)
+      if self.veto
+        self
+      else
+        other = yield
+
+        new_allow = self.allow || other.allow
+
+        new_allow_error =
+          case
+          when new_allow
+            nil
+          when self.allow_error && other.allow_error
+            self.allow_error.merge(other.allow_error)
+          else
+            self.allow_error || other.allow_error
+          end
+
+        ComposedResult.new(new_allow, other.veto, new_allow_error, other.veto_error)
+      end
+    end
+  end
+
+  ViewEnv = Struct.new(:view, :_access_control, :context) do
+    delegate :model, to: :view
+  end
+
+  EditEnv = Struct.new(:view, :_access_control, :deserialize_context, :changes) do
+    delegate :model, to: :view
+  end
+
+  PermissionsCheck = Struct.new(:location, :reason, :error_type, :checker) do
+    def name
+      "#{reason} (#{location})"
+    end
+
+    def check(env)
+      env.instance_exec(&self.checker)
+    end
+  end
+
+  # Error type when no `if` conditions succeed.
+  class NoRequiredConditionsError < ViewModel::AccessControlError
+    attr_reader :reasons
+
+    def initialize(nodes, reasons)
+      super("Action not permitted because none of the possible conditions were met.", nodes)
+      @reasons = reasons
+    end
+
+    def metadata
+      super.merge(conditions: @reasons.to_a)
+    end
+
+    def merge(other)
+      NoRequiredConditionsError.new(nodes | other.nodes,
+                                    Lazily.concat(reasons, other.reasons).uniq)
+    end
+  end
+
+  class << self
+    attr_reader :edit_valid_ifs,
+                :edit_valid_unlesses,
+                :editable_ifs,
+                :editable_unlesses,
+                :visible_ifs,
+                :visible_unlesses
+
+    def inherited(subclass)
+      super
+      subclass.initialize_as_composed_access_control
+    end
+
+    def initialize_as_composed_access_control
+      @included_checkers   = []
+
+      @edit_valid_ifs      = []
+      @edit_valid_unlesses = []
+
+      @editable_ifs        = []
+      @editable_unlesses   = []
+
+      @visible_ifs         = []
+      @visible_unlesses    = []
+
+      @view_env_class = ViewEnv
+      @edit_env_class = EditEnv
+    end
+
+    ## Configuration API
+    def include_from(ancestor)
+      unless ancestor < ViewModel::AccessControl::Composed
+        raise ArgumentError.new("Invalid ancestor: #{ancestor}")
+      end
+
+      @included_checkers << ancestor
+    end
+
+    def add_to_env(field_name)
+      if @edit_env_class == EditEnv
+        @edit_env_class = Class.new(EditEnv)
+        @view_env_class = Class.new(ViewEnv)
+      end
+
+      @edit_env_class.delegate(field_name, to: :_access_control)
+      @view_env_class.delegate(field_name, to: :_access_control)
+    end
+
+    def visible_if!(reason, &block)
+      @visible_ifs         << new_permission_check(reason, &block)
+    end
+
+    def visible_unless!(reason, &block)
+      @visible_unlesses    << new_permission_check(reason, &block)
+    end
+
+    def editable_if!(reason, &block)
+      @editable_ifs        << new_permission_check(reason, &block)
+    end
+
+    def editable_unless!(reason, &block)
+      @editable_unlesses   << new_permission_check(reason, &block)
+    end
+
+    def edit_valid_if!(reason, &block)
+      @edit_valid_ifs      << new_permission_check(reason, &block)
+    end
+
+    def edit_valid_unless!(reason, &block)
+      @edit_valid_unlesses << new_permission_check(reason, &block)
+    end
+
+    ## Implementation
+
+    def new_view_env(view, access_control, context)
+      @view_env_class.new(view, access_control, context)
+    end
+
+    def new_edit_env(view, access_control, deserialize_context, changes = nil)
+      @edit_env_class.new(view, access_control, deserialize_context, changes)
+    end
+
+    def new_permission_check(reason, error_type: ViewModel::AccessControlError, &block)
+      PermissionsCheck.new(self.name&.demodulize, reason, error_type, block)
+    end
+
+    def each_check(check_name, include_ancestor = nil)
+      return enum_for(:each_check, check_name, include_ancestor) unless block_given?
+
+      self.public_send(check_name).each { |x| yield x }
+
+      visited = Set.new
+      @included_checkers.each do |ancestor|
+        next unless visited.add?(ancestor)
+        next if include_ancestor && !include_ancestor.call(ancestor)
+        ancestor.each_check(check_name) { |x| yield x }
+      end
+    end
+
+    def inspect
+      s = super + "("
+      s += inspect_checks.join(", ")
+      s += " includes checkers: #{@included_checkers.inspect}" if @included_checkers.present?
+      s += ")"
+      s
+    end
+
+    def inspect_checks
+      checks = []
+      checks << "visible_if: #{@visible_ifs.map(&:reason)}"                if @visible_ifs.present?
+      checks << "visible_unless: #{@visible_unlesses.map(&:reason)}"       if @visible_unlesses.present?
+      checks << "editable_if: #{@editable_ifs.map(&:reason)}"              if @editable_ifs.present?
+      checks << "editable_unless: #{@editable_unlesses.map(&:reason)}"     if @editable_unlesses.present?
+      checks << "edit_valid_if: #{@edit_valid_ifs.map(&:reason)}"          if @edit_valid_ifs.present?
+      checks << "edit_valid_unless: #{@edit_valid_unlesses.map(&:reason)}" if @edit_valid_unlesses.present?
+      checks
+    end
+
+  end
+
+  # final
+  def visible_check(view, context:)
+    env = self.class.new_view_env(view, self, context)
+    check_delegates(env, self.class.each_check(:visible_ifs), self.class.each_check(:visible_unlesses))
+  end
+
+  # final
+  def editable_check(view, deserialize_context:)
+    env = self.class.new_edit_env(view, self, deserialize_context)
+    check_delegates(env, self.class.each_check(:editable_ifs), self.class.each_check(:editable_unlesses))
+  end
+
+  # final
+  def valid_edit_check(view, deserialize_context:, changes:)
+    env = self.class.new_edit_env(view, self, deserialize_context, changes)
+    check_delegates(env, self.class.each_check(:edit_valid_ifs), self.class.each_check(:edit_valid_unlesses))
+  end
+
+  protected
+
+  def check_delegates(env, ifs, unlesses)
+    vetoed_checker = unlesses.detect { |checker| checker.check(env) }
+
+    veto = vetoed_checker.present?
+    if veto
+      veto_error = vetoed_checker.error_type.new("Action not permitted because: " +
+                                                 vetoed_checker.reason,
+                                                 env.view.blame_reference)
+    end
+
+    allow = ifs.any? { |checker| checker.check(env) }
+
+    unless allow
+      allow_error = NoRequiredConditionsError.new(env.view.blame_reference,
+                                                  ifs.map(&:name))
+    end
+
+    ComposedResult.new(allow, veto, allow_error, veto_error)
+  end
+end

--- a/lib/view_model/access_control/open.rb
+++ b/lib/view_model/access_control/open.rb
@@ -1,0 +1,13 @@
+class ViewModel::AccessControl::Open < ViewModel::AccessControl
+  def visible_check(view, context:)
+    ViewModel::AccessControl::Result::PERMIT
+  end
+
+  def editable_check(view, deserialize_context:)
+    ViewModel::AccessControl::Result::PERMIT
+  end
+
+  def valid_edit_check(view, deserialize_context:, changes:)
+    ViewModel::AccessControl::Result::PERMIT
+  end
+end

--- a/lib/view_model/access_control/read_only.rb
+++ b/lib/view_model/access_control/read_only.rb
@@ -1,0 +1,13 @@
+class ViewModel::AccessControl::ReadOnly < ViewModel::AccessControl
+  def visible_check(view, context:)
+    ViewModel::AccessControl::Result::PERMIT
+  end
+
+  def editable_check(view, deserialize_context:)
+    ViewModel::AccessControl::Result::DENY
+  end
+
+  def valid_edit_check(view, deserialize_context:, changes:)
+    ViewModel::AccessControl::Result::DENY
+  end
+end

--- a/lib/view_model/access_control/tree.rb
+++ b/lib/view_model/access_control/tree.rb
@@ -1,0 +1,273 @@
+## Defines an access control discipline for a given action against a tree of
+## viewmodels.
+##
+## Extends the basic AccessControl to offer different checking based on the view
+## type and position in a viewmodel tree.
+##
+## Access checks for each given node type are specified at class level as
+## `ComposedAccessControl`s, using `view` blocks. Checks that apply to all node
+## types are specified in an `always` block.
+##
+## In addition, node types can be marked as a 'root'. Root types may permit and
+## veto access to their non-root tree descendents with the additional access
+## checks `root_children_{editable,visible}_if!` and `root_children_
+## {editable,visible}_unless!`. The results of evaluating these checks on entry
+## to the root node will be cached and used when evaluating `visible` and
+## `editable` on children.
+class ViewModel::AccessControl::Tree < ViewModel::AccessControl
+  class << self
+    attr_reader :view_policies
+
+    def inherited(subclass)
+      super
+      subclass.initialize_as_tree_access_control
+    end
+
+    def initialize_as_tree_access_control
+      @included_checkers = []
+      @view_policies     = {}
+      @env_vars          = []
+      const_set(:AlwaysPolicy, Class.new(Node))
+    end
+
+    def include_from(ancestor)
+      unless ancestor < ViewModel::AccessControl::Tree
+        raise ArgumentError.new("Invalid ancestor: #{ancestor}")
+      end
+
+      @included_checkers << ancestor
+
+      self::AlwaysPolicy.include_from(ancestor::AlwaysPolicy)
+      ancestor.view_policies.each do |view_name, ancestor_policy|
+        policy = find_or_create_policy(view_name, root: ancestor_policy.root?)
+        policy.include_from(ancestor_policy)
+      end
+    end
+
+    def add_to_env(field_name)
+      @env_vars << field_name
+      self::AlwaysPolicy.add_to_env(field_name)
+      view_policies.values.each { |p| p.add_to_env(field_name) }
+    end
+
+    # Definition language
+    def view(view_name, root: false, &block)
+      policy = find_or_create_policy(view_name, root: root)
+      policy.instance_exec(&block)
+    end
+
+    def always(&block)
+      self::AlwaysPolicy.instance_exec(&block)
+    end
+
+    ## implementation
+
+    def create_policy(view_name)
+      policy = Class.new(Node)
+      const_set(:"#{view_name}Policy", policy)
+      view_policies[view_name] = policy
+      policy.include_from(self::AlwaysPolicy)
+      @env_vars.each { |field| policy.add_to_env(field) }
+      policy
+    end
+
+    def find_or_create_policy(view_name, root:)
+      if (policy = view_policies[view_name])
+        if policy.root? != root
+          raise ArgumentError.new("Cannot create policy with root=#{root}: inconsistent with ancestors")
+        end
+      else
+        policy = create_policy(view_name)
+        policy.root! if root
+      end
+      policy
+    end
+
+    def inspect
+    "#{super}(checks:\n#{@view_policies.values.map(&:inspect).join("\n")}\n#{self::AlwaysPolicy.inspect}\nincluded checkers: #{@included_checkers})"
+    end
+  end
+
+  def initialize
+    @always_policy_instance = self.class::AlwaysPolicy.new(self)
+    @view_policy_instances  = self.class.view_policies.each_with_object({}) { |(name, policy), h| h[name] = policy.new(self) }
+  end
+
+  # Evaluation entry points
+  def visible_check(view, context:)
+    policy_instance_for(view).visible_check(view, context: context)
+  end
+
+  def editable_check(view, deserialize_context:)
+    policy_instance_for(view).editable_check(view, deserialize_context: deserialize_context)
+  end
+
+  def valid_edit_check(view, deserialize_context:, changes:)
+    policy_instance_for(view).valid_edit_check(view, deserialize_context: deserialize_context, changes: changes)
+  end
+
+  private
+
+  def policy_instance_for(view)
+    view_name = view.class.view_name
+    @view_policy_instances.fetch(view_name) { @always_policy_instance }
+  end
+
+  # Mix-in for traversal contexts to support saving precalculated
+  # child-editability/visibility for tree-based access control roots.
+  module AccessControlRootMixin
+    extend ActiveSupport::Concern
+
+    RootData = Struct.new(:visibility, :editability)
+
+    def initialize(*)
+      super
+      @access_control_root_data = nil
+    end
+
+    def initialize_as_child(*)
+      @access_control_root_data = nil
+    end
+
+    def access_control_root?
+      @access_control_root_data.present?
+    end
+
+    def nearest_access_control_root_data
+      @nearest_access_control_root_data ||=
+        if access_control_root?
+          @access_control_root_data
+        else
+          parent_context&.nearest_access_control_root_data
+        end
+    end
+
+    def set_access_control_root_editability!(root_result)
+      @access_control_root_data ||= RootData.new
+      @access_control_root_data.editability = root_result
+    end
+
+    def set_access_control_root_visibility!(root_result)
+      @access_control_root_data ||= RootData.new
+      @access_control_root_data.visibility = root_result
+    end
+  end
+
+  class Node < ViewModel::AccessControl::Composed
+    class << self
+      attr_reader :root_children_editable_ifs,
+                  :root_children_editable_unlesses,
+                  :root_children_visible_ifs,
+                  :root_children_visible_unlesses
+
+      def inherited(subclass)
+        super
+        subclass.initialize_as_node
+      end
+
+      def initialize_as_node
+        @root                            = false
+        @root_children_editable_ifs      = []
+        @root_children_editable_unlesses = []
+        @root_children_visible_ifs       = []
+        @root_children_visible_unlesses  = []
+      end
+
+      def root!
+        @root = true
+      end
+
+      def root?
+        @root
+      end
+
+      def add_to_env(parent_field)
+        delegate(parent_field, to: :@tree_access_control)
+        super(parent_field)
+      end
+
+      def root_children_visible_if!(reason, &block)
+        raise ArgumentError.new("Cannot set child access control on non-root") unless root?
+        @root_children_visible_ifs << new_permission_check(reason, &block)
+      end
+
+      def root_children_visible_unless!(reason, &block)
+        raise ArgumentError.new("Cannot set child access control on non-root") unless root?
+        @root_children_visible_unlesses << new_permission_check(reason, &block)
+      end
+
+      def root_children_editable_if!(reason, &block)
+        raise ArgumentError.new("Cannot set child access control on non-root") unless root?
+        @root_children_editable_ifs << new_permission_check(reason, &block)
+      end
+
+      def root_children_editable_unless!(reason, &block)
+        raise ArgumentError.new("Cannot set child access control on non-root") unless root?
+        @root_children_editable_unlesses << new_permission_check(reason, &block)
+      end
+
+      def inspect_checks
+        checks = super
+        checks.unshift("root: #{root?}")
+        checks << "root_children_visible_if: #{@root_children_visible_ifs.map(&:reason)}"            if @root_children_visible_ifs.present?
+        checks << "root_children_visible_unless: #{@root_children_visible_unlesses.map(&:reason)}"   if @root_children_visible_unlesses.present?
+        checks << "root_children_editable_if: #{@root_children_editable_ifs.map(&:reason)}"          if @root_children_editable_ifs.present?
+        checks << "root_children_editable_unless: #{@root_children_editable_unlesses.map(&:reason)}" if @root_children_editable_unlesses.present?
+        checks
+      end
+    end
+
+    def initialize(tree_access_control)
+      super()
+      @tree_access_control = tree_access_control
+    end
+
+    def visible_check(view, context:)
+      if self.class.root?
+        save_root_visibility!(view, context: context)
+        super
+      else
+        if (root_data = context.nearest_access_control_root_data)
+          root_data.visibility.merge { super }
+        else
+          super
+        end
+      end
+    end
+
+    def editable_check(view, deserialize_context:)
+      if self.class.root?
+        save_root_editability!(view, deserialize_context: deserialize_context)
+        super
+      else
+        if (root_data = deserialize_context.nearest_access_control_root_data)
+          root_data.editability.merge { super }
+        else
+          super
+        end
+      end
+    end
+
+    private
+
+    def save_root_visibility!(view, context:)
+      env = self.class.new_view_env(view, self, context)
+
+      result = check_delegates(env,
+                               self.class.each_check(:root_children_visible_ifs, ->(a){ a.is_a?(Node) }),
+                               self.class.each_check(:root_children_visible_unlesses, ->(a){ a.is_a?(Node) }))
+
+      context.set_access_control_root_visibility!(result)
+    end
+
+    def save_root_editability!(view, deserialize_context:)
+      env = self.class.new_edit_env(view, self, deserialize_context)
+
+      result = check_delegates(env,
+                               self.class.each_check(:root_children_editable_ifs, ->(a){ a.is_a?(Node) }),
+                               self.class.each_check(:root_children_editable_unlesses, ->(a){ a.is_a?(Node) }))
+
+      deserialize_context.set_access_control_root_editability!(result)
+    end
+  end
+end

--- a/lib/view_model/access_control_error.rb
+++ b/lib/view_model/access_control_error.rb
@@ -1,0 +1,20 @@
+class ViewModel::AccessControlError < ViewModel::AbstractError
+  attr_reader :nodes
+
+  def initialize(detail, nodes = [])
+    super(detail)
+    @nodes = Array.wrap(nodes)
+  end
+
+  def status
+    403
+  end
+
+  def metadata
+    blame_metadata(nodes)
+  end
+
+  def code
+    "AccessControl.Forbidden"
+  end
+end

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -8,7 +8,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
     associated_views = nil
     pre_rendered = owner_viewmodel.transaction do
       owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, serialize_context: serialize_context)
-      owner_view.visible!(context: serialize_context)
+      serialize_context.visible!(owner_view)
       associated_views = owner_view.load_associated(association_name, scope: scope, serialize_context: serialize_context)
 
       associated_views = yield(associated_views) if block_given?

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -180,7 +180,7 @@ class ViewModel::ActiveRecord
           # manually load unresolvable VMs, and additionally add their previous
           # parents (if present) as otherwise-unmodified roots with
           # `association_changed!` set, in order that we can correctly
-          # `editable?` check them.
+          # `editable_check` them.
 
           # If the foreign key is from child to parent, the child update has a
           # `parent_data` for the new parent set, which will include the

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -35,9 +35,15 @@ module ViewModel::Controller
   end
 
   def render_errors(error_views, status = 500)
+    error_views = Array.wrap(error_views)
+    unless error_views.all? { |ev| ev.is_a?(ViewModel) }
+      raise "Expected ViewModel error views, received #{error_views.inspect}"
+    end
+
     render_jbuilder(status: status) do |json|
-      json.errors Array.wrap(error_views) do |error_view|
-        ViewModel.serialize(error_view, json)
+      json.errors error_views do |error_view|
+        ctx = ViewModel::Error::View.new_serialize_context(access_control: ViewModel::AccessControl::Open.new)
+        ViewModel::Error::View.serialize(error_view, json, serialize_context: ctx)
       end
     end
   end

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -12,14 +12,7 @@ class ViewModel
     end
 
     def metadata
-      {
-        nodes: nodes.map do |ref|
-          {
-            ViewModel::TYPE_ATTRIBUTE => ref.viewmodel_class.view_name,
-            ViewModel::ID_ATTRIBUTE   => ref.model_id
-          }
-        end
-      }
+      blame_metadata(nodes)
     end
 
     def code

--- a/lib/view_model/deserialize_context.rb
+++ b/lib/view_model/deserialize_context.rb
@@ -1,55 +1,44 @@
-class ViewModel
-  class DeserializeContext
+require 'view_model/traversal_context'
+
+class ViewModel::DeserializeContext < ViewModel::TraversalContext
+  class SharedContext < ViewModel::TraversalContext::SharedContext
+    # During deserialization, collects a tree of viewmodel association names that
+    # were updated. Used to ensure that updated associations are always included
+    # in response serialization after deserialization, even if hidden by default.
     attr_accessor :updated_associations
-    attr_reader :parent_context, :parent_viewmodel
-    private :parent_context, :parent_viewmodel
+  end
 
-    class Changes
-      attr_reader :changed_attributes, :changed_associations, :deleted
+  def self.shared_context_class
+    SharedContext
+  end
 
-      def initialize(changed_attributes: [], changed_associations: [], deleted: false)
-        @changed_attributes   = changed_attributes.map(&:to_s)
-        @changed_associations = changed_associations.map(&:to_s)
-        @deleted              = deleted
-      end
+  delegate :updated_associations, :"updated_associations=", to: :shared_context
 
-      def deleted?
-        deleted
-      end
+  class Changes
+    attr_reader :changed_attributes, :changed_associations, :deleted
 
-      def contained_to?(associations: [], attributes: [])
-        !deleted? &&
-          changed_associations.all? { |assoc| associations.include?(assoc.to_s) } &&
-          changed_attributes.all? { |attr| attributes.include?(attr.to_s) }
-      end
+    def initialize(changed_attributes: [], changed_associations: [], deleted: false)
+      @changed_attributes   = changed_attributes.map(&:to_s)
+      @changed_associations = changed_associations.map(&:to_s)
+      @deleted              = deleted
     end
 
-    def initialize(*)
+    def deleted?
+      deleted
     end
 
-    def parent(idx = 0)
-      if idx == 0
-        parent_viewmodel
-      else
-        parent_context&.parent(idx - 1)
-      end
+    def contained_to?(associations: [], attributes: [])
+      !deleted? &&
+        changed_associations.all? { |assoc| associations.include?(assoc.to_s) } &&
+        changed_attributes.all? { |attr| attributes.include?(attr.to_s) }
     end
+  end
 
-    def parent_ref(idx = 0)
-      parent(idx)&.to_reference
-    end
+  def initial_editability(view)
+    shared_context.access_control.initial_editability(view, deserialize_context: self)
+  end
 
-    def for_child(parent_viewmodel)
-      self.dup.tap do |copy|
-        copy.initialize_as_child(self, parent_viewmodel)
-      end
-    end
-
-    protected
-
-    def initialize_as_child(parent_context, parent_viewmodel)
-      @parent_context   = parent_context
-      @parent_viewmodel = parent_viewmodel
-    end
+  def editable!(view, initial_editability: nil, changes:)
+    shared_context.access_control.editable!(view, initial_editability: initial_editability, deserialize_context: self, changes: changes)
   end
 end

--- a/lib/view_model/error.rb
+++ b/lib/view_model/error.rb
@@ -12,6 +12,17 @@ class ViewModel::AbstractError < StandardError
   def view
     ViewModel::Error::View.new(self)
   end
+
+  def blame_metadata(viewmodel_refs)
+    {
+      nodes: nodes.map do |ref|
+        {
+          ViewModel::TYPE_ATTRIBUTE => ref.viewmodel_class.view_name,
+          ViewModel::ID_ATTRIBUTE   => ref.model_id
+        }
+      end
+    }
+  end
 end
 
 class ViewModel::Error < ViewModel::AbstractError

--- a/lib/view_model/traversal_context.rb
+++ b/lib/view_model/traversal_context.rb
@@ -1,0 +1,74 @@
+require 'view_model/access_control/tree'
+
+# Abstract base for Serialize and DeserializeContexts.
+class ViewModel::TraversalContext
+  class SharedContext
+    attr_reader :access_control
+
+    def initialize(access_control: ViewModel::AccessControl::Open.new)
+      @access_control = access_control
+    end
+  end
+
+  def self.shared_context_class
+    SharedContext
+  end
+
+  attr_reader :shared_context
+  delegate :access_control, to: :shared_context
+
+  # Mechanism for marking nodes as access-control roots and saving their child-visibility
+  include ViewModel::AccessControl::Tree::AccessControlRootMixin
+
+  def self.new_child(*args)
+    self.allocate.tap { |c| c.initialize_as_child(*args) }
+  end
+
+  def initialize(shared_context: nil, **shared_context_params)
+    super()
+    @shared_context   = shared_context || self.class.shared_context_class.new(**shared_context_params)
+    @parent_context   = nil
+    @parent_viewmodel = nil
+  end
+
+  # Overloaded constructor for initialization of descendent node contexts.
+  # Shared context is the same, ancestry is established, and subclasses can
+  # override to maintain other node-specific state.
+  def initialize_as_child(shared_context:, parent_context:, parent_viewmodel:)
+    super()
+    @shared_context = shared_context
+    @parent_context = parent_context
+    @parent_viewmodel = parent_viewmodel
+  end
+
+  def for_child(parent_viewmodel, **rest)
+    self.class.new_child(shared_context: shared_context,
+                         parent_context: self,
+                         parent_viewmodel: parent_viewmodel,
+                         **rest)
+  end
+
+  def parent_context(idx = 0)
+    if idx == 0
+      @parent_context
+    else
+      @parent_context&.parent_context(idx - 1)
+    end
+  end
+
+  def parent_viewmodel(idx = 0)
+    if idx == 0
+      @parent_viewmodel
+    else
+      parent_context(idx - 1)&.parent_viewmodel
+    end
+  end
+
+  def parent_ref(idx = 0)
+    parent_viewmodel(idx)&.to_reference
+  end
+
+  def visible!(view)
+    access_control.visible!(view, context: self)
+  end
+end

--- a/test/helpers/controller_test_helpers.rb
+++ b/test/helpers/controller_test_helpers.rb
@@ -216,23 +216,27 @@ module ControllerTestControllers
     Class.new(DummyController) do |c|
       Object.const_set(:ParentController, self)
       include ViewModel::ActiveRecord::Controller
+      self.access_control = ViewModel::AccessControl::Open
     end
 
     Class.new(DummyController) do |c|
       Object.const_set(:ChildController, self)
       include ViewModel::ActiveRecord::Controller
+      self.access_control = ViewModel::AccessControl::Open
       nested_in :parent, as: :children
     end
 
     Class.new(DummyController) do |c|
       Object.const_set(:LabelController, self)
       include ViewModel::ActiveRecord::Controller
+      self.access_control = ViewModel::AccessControl::Open
       nested_in :parent, as: :label
     end
 
     Class.new(DummyController) do |c|
       Object.const_set(:TargetController, self)
       include ViewModel::ActiveRecord::Controller
+      self.access_control = ViewModel::AccessControl::Open
       nested_in :parent, as: :target
     end
   end

--- a/test/unit/view_model/access_control_test.rb
+++ b/test/unit/view_model/access_control_test.rb
@@ -1,0 +1,612 @@
+require_relative "../../helpers/arvm_test_utilities.rb"
+require_relative "../../helpers/arvm_test_models.rb"
+
+require "minitest/autorun"
+require 'minitest/unit'
+
+require "view_model/active_record"
+
+class ViewModel::AccessControlTest < ActiveSupport::TestCase
+  include ARVMTestUtilities
+
+  module Assertions
+    def assert_serializes(vm, model, serialize_context: vm.new_serialize_context)
+      h = vm.new(model).to_hash(serialize_context: serialize_context)
+      assert_kind_of(Hash, h)
+    end
+
+    def refute_serializes(vm, model, message = nil, serialize_context: vm.new_serialize_context)
+      ex = assert_raises(ViewModel::AccessControlError) do
+        vm.new(model).to_hash(serialize_context: serialize_context)
+      end
+      assert_match(message, ex.message) if message
+      ex
+    end
+
+    def assert_deserializes(vm, model,
+                            deserialize_context: vm.new_deserialize_context,
+                            serialize_context: vm.new_serialize_context,
+                            &block)
+      alter_by_view!(vm, model,
+                     deserialize_context: deserialize_context,
+                     serialize_context: serialize_context,
+                     &block)
+    end
+
+    def refute_deserializes(vm, model, message = nil,
+                            deserialize_context: vm.new_deserialize_context,
+                            serialize_context: vm.new_serialize_context,
+                            &block)
+      ex = assert_raises(ViewModel::AccessControlError) do
+        alter_by_view!(vm, model,
+                       deserialize_context: deserialize_context,
+                       serialize_context: serialize_context,
+                       &block)
+      end
+      assert_match(message, ex.message) if message
+      ex
+    end
+  end
+
+  class ComposedTest < ActiveSupport::TestCase
+    include ARVMTestUtilities
+    include Assertions
+
+    def before_all
+      super
+
+      build_viewmodel(:List) do
+        define_schema do |t|
+          t.string  :car
+          t.integer :cdr_id
+        end
+
+        define_model do
+          belongs_to :cdr, class_name: :List, dependent: :destroy
+        end
+
+        define_viewmodel do
+          attribute   :car
+          association :cdr
+
+          def self.new_serialize_context(**args)
+            super(access_control: TestAccessControl.new, **args)
+          end
+
+          def self.new_deserialize_context(**args)
+            super(access_control: TestAccessControl.new, **args)
+          end
+        end
+      end
+    end
+
+    def setup
+      ComposedTest.const_set(:TestAccessControl, Class.new(ViewModel::AccessControl::Composed))
+      enable_logging!
+    end
+
+    def teardown
+      ComposedTest.send(:remove_const, :TestAccessControl)
+    end
+
+    def test_visible_if
+      TestAccessControl.visible_if!("car is visible1") do
+        view.car == "visible1"
+      end
+
+      TestAccessControl.visible_if!("car is visible2") do
+        view.car == "visible2"
+      end
+
+      assert_serializes(ListView, List.create!(car: "visible1"))
+      assert_serializes(ListView, List.create!(car: "visible2"))
+      ex = refute_serializes(ListView, List.create!(car: "bad"), /none of the possible/)
+      assert_equal(2, ex.reasons.count)
+    end
+
+    def test_visible_unless
+      TestAccessControl.visible_if!("always") { true }
+
+      TestAccessControl.visible_unless!("car is invisible") do
+        view.car == "invisible"
+      end
+
+      assert_serializes(ListView, List.create!(car: "ok"))
+      refute_serializes(ListView, List.create!(car: "invisible"), /not permitted.*car is invisible/)
+    end
+
+    def test_editable_if
+      TestAccessControl.visible_if!("always") { true }
+
+      TestAccessControl.editable_if!("car is editable1") do
+        view.car == "editable1"
+      end
+
+      TestAccessControl.editable_if!("car is editable2") do
+        view.car == "editable2"
+      end
+
+      assert_deserializes(ListView, List.create!(car: "editable1")) { |v, _| v["car"] = "unchecked" }
+      assert_deserializes(ListView, List.create!(car: "editable2")) { |v, _| v["car"] = "unchecked" }
+      assert_deserializes(ListView, List.create!(car: "forbidden")) { |v, _| v["car"] = "forbidden" } # no change so permitted
+      refute_deserializes(ListView, List.create!(car: "forbidden"), /none of the possible/) { |v, _| v["car"] = "unchecked" }
+    end
+
+    def test_editable_unless
+      TestAccessControl.visible_if!("always") { true }
+      TestAccessControl.editable_if!("always") { true }
+
+      TestAccessControl.editable_unless!("car is uneditable") do
+        view.car == "uneditable"
+      end
+
+      assert_deserializes(ListView, List.create!(car: "ok")) { |v, _| v["car"] = "unchecked" }
+      assert_deserializes(ListView, List.create!(car: "uneditable")) { |v, _| v["car"] = "uneditable" } # no change so permitted
+      refute_deserializes(ListView, List.create!(car: "uneditable"), /car is uneditable/) { |v, _| v["car"] = "unchecked" }
+    end
+
+    def test_edit_valid_if
+      TestAccessControl.visible_if!("always") { true }
+
+      TestAccessControl.edit_valid_if!("car is validedit") do
+        view.car == "validedit"
+      end
+
+      assert_deserializes(ListView, List.create!(car: "unchecked"))  { |v, _| v["car"] = "validedit" }
+      assert_deserializes(ListView, List.create!(car: "unmodified")) { |v, _| v["car"] = "unmodified" } # no change so permitted
+      refute_deserializes(ListView, List.create!(car: "unchecked"), /none of the possible/) { |v, _| v["car"] = "bad" }
+    end
+
+    def test_edit_valid_unless
+      TestAccessControl.visible_if!("always") { true }
+      TestAccessControl.edit_valid_if!("always") { true }
+      TestAccessControl.edit_valid_unless!("car is invalidedit") do
+        view.car == "invalidedit"
+      end
+
+      assert_deserializes(ListView, List.create!(car: "unchecked"))   { |v, _| v["car"] = "ok" }
+      assert_deserializes(ListView, List.create!(car: "invalidedit")) { |v, _| v["car"] = "invalidedit" }
+      refute_deserializes(ListView, List.create!(car: "unchecked"), /car is invalidedit/) { |v, _| v["car"] = "invalidedit" }
+    end
+
+    def test_editable_and_edit_valid
+      TestAccessControl.visible_if!("always") { true }
+
+      TestAccessControl.editable_if!("original car permits") do
+        view.car == "permitoriginal"
+      end
+
+      TestAccessControl.edit_valid_if!("resulting car permits") do
+        view.car == "permitresult"
+      end
+
+      # at least one valid
+      assert_deserializes(ListView, List.create!(car: "permitoriginal")) { |v, _| v["car"] = "permitresult" }
+      assert_deserializes(ListView, List.create!(car: "badoriginal"))    { |v, _| v["car"] = "permitresult" }
+      assert_deserializes(ListView, List.create!(car: "permitoriginal")) { |v, _| v["car"] = "badresult" }
+
+      # no valid
+      ex = refute_deserializes(ListView, List.create!(car: "badoriginal"), /none of the possible/) { |v, _| v["car"] = "badresult" }
+
+      assert_equal(2, ex.reasons.count)
+    end
+
+    def test_inheritance
+      child_access_control = Class.new(ViewModel::AccessControl::Composed)
+      child_access_control.include_from(TestAccessControl)
+
+      TestAccessControl.visible_if!("car is ancestor") { view.car == "ancestor" }
+      child_access_control.visible_if!("car is descendent") { view.car == "descendent" }
+
+      s_ctx = ListView.new_serialize_context(access_control: child_access_control.new)
+
+      assert_serializes(ListView, List.create!(car: "ancestor"), serialize_context: s_ctx)
+      assert_serializes(ListView, List.create!(car: "descendent"), serialize_context: s_ctx)
+      ex = refute_serializes(ListView, List.create!(car: "foreigner"), serialize_context: s_ctx)
+      assert_equal(2, ex.reasons.count)
+    end
+
+    def test_add_to_env
+      TestAccessControl.class_eval do
+        attr_reader :env_data
+        def initialize(env_data = "data")
+          @env_data = env_data
+        end
+        add_to_env :env_data
+      end
+
+      TestAccessControl.visible_if!("car matches env_data") { view.car == env_data }
+
+      assert_serializes(ListView, List.create!(car: "data"))
+      refute_serializes(ListView, List.create!(car: "failure"))
+
+      s_ctx = ListView.new_serialize_context(access_control: TestAccessControl.new("data2"))
+      assert_serializes(ListView, List.create!(car: "data2"), serialize_context: s_ctx)
+    end
+  end
+
+  class TreeTest < ActiveSupport::TestCase
+    include ARVMTestUtilities
+    include Assertions
+
+    def before_all
+      super
+
+      build_viewmodel(:Tree1) do
+        define_schema do |t|
+          t.string  :val
+          t.integer :tree2_id
+        end
+
+        define_model do
+          belongs_to :tree2, class_name: :Tree2, dependent: :destroy
+        end
+
+        define_viewmodel do
+          attribute   :val
+          association :tree2
+
+          def self.new_serialize_context(**args)
+            super(access_control: TestAccessControl.new, **args)
+          end
+
+          def self.new_deserialize_context(**args)
+            super(access_control: TestAccessControl.new, **args)
+          end
+        end
+      end
+
+      build_viewmodel(:Tree2) do
+        define_schema do |t|
+          t.string  :val
+          t.integer :tree1_id
+        end
+
+        define_model do
+          belongs_to :tree1, class_name: :Tree1, dependent: :destroy
+        end
+
+        define_viewmodel do
+          attribute   :val
+          association :tree1
+        end
+      end
+    end
+
+    def setup
+      TreeTest.const_set(:TestAccessControl, Class.new(ViewModel::AccessControl::Tree))
+      enable_logging!
+    end
+
+    def teardown
+      TreeTest.send(:remove_const, :TestAccessControl)
+    end
+
+    def make_tree(*vals)
+      tree = vals.each_slice(2).reverse_each.inject(nil) do |rest, (t1, t2)|
+        Tree1.new(val: t1, tree2: Tree2.new(val: t2, tree1: rest))
+      end
+      tree.save!
+      tree
+    end
+
+    def test_visibility_from_root
+      TestAccessControl.view "Tree1", root: true do
+        visible_if!("true") { true }
+
+        root_children_visible_if!("root children visible") do
+          view.val == "visible_children"
+        end
+      end
+
+      refute_serializes(Tree1View, make_tree("visible", "invisible"))
+      assert_serializes(Tree1View, make_tree("visible_children", "invisible"))
+
+      # nested root
+      refute_serializes(Tree1View, make_tree("visible_children", "invisible", "visible", "invisible"))
+      assert_serializes(Tree1View, make_tree("visible_children", "invisible", "visible_children", "visible"))
+    end
+
+    def test_visibility_veto_from_root
+      TestAccessControl.view "Tree1", root: true do
+        root_children_visible_unless!("root children invisible") do
+          view.val == "invisible_children"
+        end
+      end
+
+      TestAccessControl.always do
+        visible_if!("true") { true }
+      end
+
+      assert_serializes(Tree1View, make_tree("visible", "visible"))
+      refute_serializes(Tree1View, make_tree("invisible_children", "invisible"))
+
+      # nested root
+      assert_serializes(Tree1View, make_tree("visible", "visible", "visible", "visible"))
+      refute_serializes(Tree1View, make_tree("visible", "visible", "invisible_children", "invisible"))
+    end
+
+    def test_editability_from_root
+      TestAccessControl.always do
+        visible_if!("always") { true }
+      end
+
+      TestAccessControl.view "Tree1", root: true do
+        editable_if!("true") { true }
+
+        root_children_editable_if!("root children editable") do
+          view.val == "editable_children"
+        end
+      end
+
+
+      refute_deserializes(Tree1View, make_tree("editable", "uneditable")) { |v, _|
+        v["tree2"]["val"] = "change"
+      }
+
+      assert_deserializes(Tree1View, make_tree("editable_children", "editable")) { |v, _|
+        v["tree2"]["val"] = "change"
+      }
+
+      # nested root
+      refute_deserializes(Tree1View, make_tree("editable_children", "uneditable", "editable", "uneditable")) { |v, _|
+        v["tree2"]["tree1"]["tree2"]["val"] = "change"
+      }
+
+      assert_deserializes(Tree1View, make_tree("editable_children", "uneditable", "editable_children", "editable")) { |v, _|
+        v["tree2"]["tree1"]["tree2"]["val"] = "change"
+      }
+    end
+
+    def test_editability_veto_from_root
+      TestAccessControl.always do
+        visible_if!("always") { true }
+        editable_if!("always") { true }
+      end
+
+      TestAccessControl.view "Tree1", root: true do
+        root_children_editable_unless!("root children uneditable") do
+          view.val == "uneditable_children"
+        end
+      end
+
+
+      refute_deserializes(Tree1View, make_tree("uneditable_children", "uneditable")) { |v, _|
+        v["tree2"]["val"] = "change"
+      }
+
+      assert_deserializes(Tree1View, make_tree("editable", "editable")) { |v, _|
+        v["tree2"]["val"] = "change"
+      }
+
+      # nested root
+      refute_deserializes(Tree1View, make_tree("editable", "editable", "uneditable_children", "uneditable")) { |v, _|
+        v["tree2"]["tree1"]["tree2"]["val"] = "change"
+      }
+
+      assert_deserializes(Tree1View, make_tree("editable", "editable", "editable", "editable")) { |v, _|
+        v["tree2"]["tree1"]["tree2"]["val"] = "change"
+      }
+    end
+
+    def test_type_independence
+      TestAccessControl.view "Tree1" do
+        visible_if!("tree1 visible") do
+          view.val == "tree1visible"
+        end
+      end
+
+      TestAccessControl.view "Tree2" do
+        visible_if!("tree2 visible") do
+          view.val == "tree2visible"
+        end
+      end
+
+      refute_serializes(Tree1View, make_tree("tree1invisible","tree2visible"))
+      assert_serializes(Tree1View, make_tree("tree1visible", "tree2visible"))
+      refute_serializes(Tree1View, make_tree("tree1visible", "tree2invisible"))
+    end
+
+    def test_visibility_always_composition
+      TestAccessControl.view "Tree1" do
+        visible_if!("tree1 visible") do
+          view.val == "tree1visible"
+        end
+      end
+
+      TestAccessControl.always do
+        visible_if!("tree2 visible") do
+          view.val == "alwaysvisible"
+        end
+      end
+
+      refute_serializes(Tree1View, Tree1.create(val: "bad"))
+      assert_serializes(Tree1View, Tree1.create(val: "tree1visible"))
+      assert_serializes(Tree1View, Tree1.create(val: "alwaysvisible"))
+    end
+
+    def test_editability_always_composition
+      TestAccessControl.view "Tree1" do
+        editable_if!("editable1")   { view.val == "editable1" }
+        edit_valid_if!("editvalid1") { view.val == "editvalid1" }
+      end
+
+      TestAccessControl.always do
+        editable_if!("editable2")   { view.val == "editable2" }
+        edit_valid_if!("editvalid2") { view.val == "editvalid2" }
+
+        visible_if!("always") { true }
+      end
+
+
+      refute_deserializes(Tree1View, Tree1.create!(val: "bad")) { |v, _| v["val"] = "alsobad" }
+
+      assert_deserializes(Tree1View, Tree1.create!(val: "editable1")) { |v, _| v["val"] = "unchecked" }
+      assert_deserializes(Tree1View, Tree1.create!(val: "editable2")) { |v, _| v["val"] = "unchecked" }
+
+      assert_deserializes(Tree1View, Tree1.create!(val: "unchecked")) { |v, _| v["val"] = "editvalid1" }
+      assert_deserializes(Tree1View, Tree1.create!(val: "unchecked")) { |v, _| v["val"] = "editvalid2" }
+    end
+
+    def test_ancestry
+      TestAccessControl.view "Tree1" do
+        visible_if!("parent tree1") { view.val == "parenttree1" }
+      end
+
+      TestAccessControl.always do
+        visible_if!("parent always") { view.val == "parentalways" }
+      end
+
+      # Child must be set up after parent is fully defined
+      child_access_control = Class.new(ViewModel::AccessControl::Tree)
+      child_access_control.include_from(TestAccessControl)
+
+      child_access_control.view "Tree1" do
+        visible_if!("child tree1") { view.val == "childtree1" }
+      end
+
+      child_access_control.always do
+        visible_if!("child always") { view.val == "childalways" }
+      end
+
+      s_ctx = Tree1View.new_serialize_context(access_control: child_access_control.new)
+
+      refute_serializes(Tree1View, Tree1.create!(val: "bad"), serialize_context: s_ctx)
+
+      assert_serializes(Tree1View, Tree1.create!(val: "parenttree1"), serialize_context: s_ctx)
+      assert_serializes(Tree1View, Tree1.create!(val: "parentalways"), serialize_context: s_ctx)
+      assert_serializes(Tree1View, Tree1.create!(val: "childtree1"), serialize_context: s_ctx)
+      assert_serializes(Tree1View, Tree1.create!(val: "childalways"), serialize_context: s_ctx)
+    end
+
+    def test_add_to_env
+      TestAccessControl.class_eval do
+        attr_reader :env_data
+        def initialize(env_data = "data")
+          super()
+          @env_data = env_data
+        end
+      end
+
+      TestAccessControl.add_to_env :env_data
+
+      TestAccessControl.view "Tree1" do
+        visible_if!("val matches env_data") { view.val == env_data }
+      end
+
+      TestAccessControl.always do
+        visible_if!("val starts with env_data") { view.val.start_with?(env_data) }
+      end
+
+      assert_serializes(Tree1View, Tree1.create!(val: "data"))
+      assert_serializes(Tree1View, Tree1.create!(val: "data-plus"))
+      refute_serializes(Tree1View, Tree1.create!(val: "bad-data"))
+
+      s_ctx = Tree1View.new_serialize_context(access_control: TestAccessControl.new("other"))
+
+      assert_serializes(Tree1View, Tree1.create!(val: "other"), serialize_context: s_ctx)
+    end
+  end
+
+  # Test edit check integration: do the various access control methods get
+  # called as expected, with expected parameters?
+  class IntegrationTest < ActiveSupport::TestCase
+    include ARVMTestUtilities
+
+    def before_all
+      build_viewmodel(:List) do
+        define_schema do |t|
+          t.string  :car
+          t.integer :cdr_id
+        end
+
+        define_model do
+          belongs_to :cdr, class_name: :List, dependent: :destroy
+        end
+
+        define_viewmodel do
+          attribute   :car
+          association :cdr
+        end
+      end
+    end
+
+    # Extract edit check changes for a given view as an array.
+    def edit_check(ctx, ref)
+      changes = ctx.valid_edit_changes(ref)
+      [changes.changed_attributes, changes.changed_associations, changes.deleted]
+    end
+
+    def test_changes_types
+      l = List.create!
+      lv, ctx = alter_by_view!(ListView, l) do |view, refs|
+        view["car"] = "a"
+        view["cdr"] = { "_type" => "List", "car" => "b" }
+      end
+
+      lv_changes = ctx.valid_edit_changes(lv.to_reference)
+
+      assert_equal(["cdr_id", "car"], lv_changes.changed_attributes)
+      assert_equal(["cdr"], lv_changes.changed_associations)
+      assert_equal(false,   lv_changes.deleted)
+    end
+
+    def test_editable_change_attribute
+      l = List.create!(car: "a")
+
+      _lv, ctx = alter_by_view!(ListView, l) do |view, refs|
+        view["car"] = nil
+      end
+
+      edits = edit_check(ctx, ViewModel::Reference.new(ListView, l.id))
+      assert_equal([["car"], [], false], edits)
+    end
+
+    def test_editable_add_association
+      l = List.create!(car: "a")
+
+      _lv, ctx = alter_by_view!(ListView, l) do |view, refs|
+        view["cdr"] = { "_type" => "List", "car" => "b" }
+      end
+
+      l_edits = edit_check(ctx, ViewModel::Reference.new(ListView, l.id))
+      assert_equal([["cdr_id"], ["cdr"], false], l_edits)
+
+      c_edits = edit_check(ctx, ViewModel::Reference.new(ListView, nil))
+      assert_equal([["car"], [], false], c_edits)
+    end
+
+    def test_editable_change_association
+      l = List.create!(car: "a", cdr: List.new(car: "b"))
+      l2 = l.cdr
+
+      _lv, ctx = alter_by_view!(ListView, l) do |view, refs|
+        view["cdr"] = { "_type" => "List", "car" => "c" }
+      end
+
+      l_edits = edit_check(ctx, ViewModel::Reference.new(ListView, l.id))
+      assert_equal([["cdr_id"], ["cdr"], false], l_edits)
+
+      l2_edits = edit_check(ctx, ViewModel::Reference.new(ListView, l2.id))
+      assert_equal([[], [], true], l2_edits)
+
+      c_edits = edit_check(ctx, ViewModel::Reference.new(ListView, nil))
+      assert_equal([["car"], [], false], c_edits)
+    end
+
+    def test_editable_delete_association
+      l = List.create!(car: "a", cdr: List.new(car: "b"))
+      l2 = l.cdr
+
+      _lv, ctx = alter_by_view!(ListView, l) do |view, refs|
+        view["cdr"] = nil
+      end
+
+      l_edits = edit_check(ctx, ViewModel::Reference.new(ListView, l.id))
+      assert_equal([["cdr_id"], ["cdr"], false], l_edits)
+
+      l2_edits = edit_check(ctx, ViewModel::Reference.new(ListView, l2.id))
+      assert_equal([[], [], true], l2_edits)
+    end
+  end
+end

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -128,12 +128,12 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_editability_raises
     no_edit_context = ParentView.new_deserialize_context(can_edit: false)
 
-    assert_raises(ViewModel::DeserializationError) do
+    assert_raises(ViewModel::AccessControlError) do
       # append child
       ParentView.new(@parent1).append_associated(:children, { "_type" => "Child", "text" => "hi" }, deserialize_context: no_edit_context)
     end
 
-    assert_raises(ViewModel::DeserializationError) do
+    assert_raises(ViewModel::AccessControlError) do
       # destroy child
       ParentView.new(@parent1).delete_associated(:children, ChildView.new(@parent1.children.first), deserialize_context: no_edit_context)
     end

--- a/test/unit/view_model/active_record/has_many_through_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_test.rb
@@ -198,11 +198,14 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
   end
 
   def test_reordering
-    alter_by_view!(ParentView, @parent1, serialize_context: context_with(:tags)) do |view, refs|
+    _pv, ctx = alter_by_view!(ParentView, @parent1, serialize_context: context_with(:tags)) do |view, refs|
       view['tags'].reverse!
     end
     assert_equal([@tag2, @tag1],
                  @parent1.parents_tags.order(:position).map(&:tag))
+
+    expected_edit_checks = Set[ViewModel::Reference.new(ParentView, @parent1.id)]
+    assert_equal(expected_edit_checks, ctx.valid_edit_checks.to_set)
   end
 
   def test_child_edit_doesnt_editcheck_parent

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -32,16 +32,37 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
     end
 
     class DeserializeContext < ViewModel::DeserializeContext
-      attr_reader :targets
+      class SharedContext < ViewModel::DeserializeContext::SharedContext
+        attr_reader :targets
+        def initialize(targets: [], **rest)
+          super(**rest)
+          @targets = targets
+        end
+      end
 
-      def initialize(targets: [], **rest)
+      def self.shared_context_class
+        SharedContext
+      end
+
+      delegate :targets, to: :shared_context
+
+      def initialize(**rest)
         super(**rest)
-        @targets = targets
       end
     end
 
     def self.deserialize_context_class
       DeserializeContext
+    end
+
+    class SerializeContext < ViewModel::SerializeContext
+      def initialize(**rest)
+        super(**rest)
+      end
+    end
+
+    def self.serialize_context_class
+      SerializeContext
     end
 
     def self.resolve_viewmodel(type, version, id, new, view_hash, deserialize_context:)

--- a/test/unit/view_model_test.rb
+++ b/test/unit/view_model_test.rb
@@ -17,37 +17,37 @@ end
 class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
   def test_serialize
     s = TestViewModel.new("a")
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(TestViewModel.serialize_to_hash(s),
                  { "name" => "a" })
   end
 
   def test_default_serialize
     s = DefaultViewModel.new("a", 1)
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(TestViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => 1 })
   end
 
   def test_default_serialize_array
     s = DefaultViewModel.new("a", [1,2])
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(TestViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => [1,2] })
   end
 
   def test_default_serialize_hash
     s = DefaultViewModel.new("a", { "x" => "y" })
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(DefaultViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => { "x" => "y" } })
   end
 
   def test_default_serialize_viewmodel
     s = DefaultViewModel.new("a", DefaultViewModel.new(1, 2))
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(DefaultViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => { "foo" => 1, "bar" => 2 } })
   end
 
   def test_default_serialize_array_of_viewmodel
     s = DefaultViewModel.new("a", [TestViewModel.new("x"), TestViewModel.new("y")])
-    assert_equal(ViewModel.serialize_to_hash(s),
+    assert_equal(DefaultViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => [{"name" => "x"}, {"name" => "y"}] })
   end
 end


### PR DESCRIPTION
Access control implemented directly in viewmodels is not flexible enough for our needs, and also awkwardly binds together controller and view concerns. Here we attempt to pull them out into a separate access control checking discipline that belongs to the controller.