### PR TITLE
Nest deserialize context in AssociationManipulation

### DIFF
--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -129,7 +129,7 @@ module AssociationManipulation
         end
       end
 
-      updated_viewmodels = update_context.run!(deserialize_context: deserialize_context)
+      updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self))
 
       if association_data.through?
         updated_viewmodels.map! do |direct_vm|
@@ -199,10 +199,11 @@ module AssociationManipulation
                 blame_reference)
       end
 
+      child_context = deserialize_context.for_child(self)
       vm = direct_viewmodel.new(models.first)
-      vm.visible!(context: deserialize_context)
-      vm.editable!(deserialize_context: deserialize_context)
-      vm.valid_edit!(deserialize_context: deserialize_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
+      vm.visible!(context: child_context)
+      vm.editable!(deserialize_context: child_context)
+      vm.valid_edit!(deserialize_context: child_context, changes: ViewModel::DeserializeContext::Changes.new(deleted: true))
       association.delete(vm.model)
       vm
     end


### PR DESCRIPTION
Create properly nested deserialize contexts including the parent when manipulating associations. Necessary to establish ancestry for inherited access control.

What should we do for `load_associated`? That's not actually performing a serialization - the serialize_context is used only for `preload_for_serialization` (i.e. prune/include). Where should that be rooted? It'd be consistent with deserialization to root on the parent, but it might be a bit weird to have to double-specify the association in prune/includes (`load_associated(:foos, serialize_context: Type.new_serialize_context(include: { :foos => :bars }))`)