### PR TITLE
Extract method for wrapping array-or-object input

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -363,6 +363,7 @@ class ViewModel
   end
 end
 
+require 'view_model/utils'
 require 'view_model/error'
 require 'view_model/deserialization_error'
 require 'view_model/serialization_error'

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -57,9 +57,7 @@ class ViewModel::Record < ViewModel
     end
 
     def deserialize_from_view(view_hashes, references: {}, deserialize_context: new_deserialize_context)
-      return_array = view_hashes.is_a?(Array)
-
-      viewmodels = Array.wrap(view_hashes).map do |view_hash|
+      ViewModel::Utils.map_one_or_many(view_hashes) do |view_hash|
         view_hash = view_hash.dup
         type, version, id, new = ViewModel.extract_viewmodel_metadata(view_hash)
 
@@ -82,8 +80,6 @@ class ViewModel::Record < ViewModel
 
         viewmodel
       end
-
-      return_array ? viewmodels : viewmodels.first
     end
 
     def deserialize_members_from_view(viewmodel, view_hash, references:, deserialize_context:)

--- a/lib/view_model/utils.rb
+++ b/lib/view_model/utils.rb
@@ -1,0 +1,15 @@
+class ViewModel::Utils
+  class << self
+    def wrap_one_or_many(obj)
+      return_array = obj.is_a?(Array)
+      results = yield(Array.wrap(obj))
+      return_array ? results : results.first
+    end
+
+    def map_one_or_many(obj)
+      wrap_one_or_many(obj) do |objs|
+        objs.map { |x| yield x }
+      end
+    end
+  end
+end


### PR DESCRIPTION
It's an extremely common pattern to wrap array-or-object input in an array, operate on it, and then return in the same format as when called. Replace ad-hoc implementations of pattern with a utility method.